### PR TITLE
Update .travis.yml: test on julia 0.4, 0.5, master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,8 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.4
+  - 0.5
   - nightly
 notifications:
   email: false


### PR DESCRIPTION
Without this change, Travis will soon no longer test on julia 0.4.  (Of course, the tests are currently broken on julia 0.5 and master.)