### PR TITLE
Allow nested reshape and view

### DIFF
--- a/src/auxiliary/strideddata.jl
+++ b/src/auxiliary/strideddata.jl
@@ -17,12 +17,12 @@ import Base.StridedReshapedArray
 
 StridedSubArray{T,N,A<:Union{DenseArray{T},StridedReshapedArray{T}},I<:Tuple{Vararg{Union{Base.RangeIndex, Base.AbstractCartesianIndex}}}} =  SubArray{T,N,A,I}
 
-StridedData(a::Array{T}, strides::IndexTuple{N} = strides(a), ::Type{Val{C}} = Val{:N}) where {N,T,C} =
-    StridedData{N,T,C}(vec(a), strides, 1)
-StridedData(a::StridedReshapedArray{T}, strides::IndexTuple{N} = strides(a), ::Type{Val{C}} = Val{:N}) where {N,T,C} =
-    StridedData{N,T,C}(vec(a.parent), strides, 1)
-StridedData(a::StridedSubArray{T}, strides::IndexTuple{N} = strides(a), ::Type{Val{C}} = Val{:N}) where {N,T,C} =
-    StridedData{N,T,C}(vec(a.parent), strides, Base.first_index(a))
+StridedData(a::Array{T}, strides::IndexTuple{N} = strides(a), ::Type{Val{C}} = Val{:N}; offset::Int = 0) where {N,T,C} =
+    StridedData{N,T,C}(vec(a), strides, 1+offset)
+StridedData(a::StridedReshapedArray{T}, strides::IndexTuple{N} = strides(a), ::Type{Val{C}} = Val{:N}; offset::Int = 0) where {N,T,C} =
+    StridedData(a.parent, strides, Val{C}; offset = offset)
+StridedData(a::StridedSubArray{T}, strides::IndexTuple{N} = strides(a), ::Type{Val{C}} = Val{:N}; offset::Int = 0) where {N,T,C} =
+    StridedData(a.parent, strides, Val{C}; offset = offset+Base.first_index(a)-1)
 
 Base.getindex(a::NormalStridedData, i) = a.data[i]
 Base.getindex(a::ConjugatedStridedData, i) = conj(a.data[i])

--- a/test/tensor.jl
+++ b/test/tensor.jl
@@ -195,3 +195,9 @@ C=randn(D,D,D,D);
 @test_throws TensorOperations.IndexError begin
     @tensor C[a,b,c,d] = conj(A[c,a])*B[c,b]
 end
+
+A=reshape(collect(96.0:99.0),2,1,2)
+B=collect(1.0:20.0)
+C=view(reshape(view(reshape(view(B,2:17),2,2,4),:,:,2:3),2,1,4),:,:,1:2)
+@tensor C[a,b,c] = A[a,b,c]
+@test B == vcat(1.0:5.0,96.0:99.0,10.0:20.0)


### PR DESCRIPTION
The existing implementation doesn't play well with mixed `reshape` and `view`. I originally hit this issue trying to `reshape` inside a `LinearMap` for `eigs`, but here's a simpler example:

```julia
julia> using TensorOperations
julia> dest_ = collect(1.0:4.0)
julia> dest = reshape(view(dest_, 2:3), 1, 2)
julia> src = zeros(dest)
julia> @tensor dest[i,j] = src[i,j]
julia> print(dest)
[2.0 3.0]
julia> print(dest_)
[1.0, 2.0, 3.0, 4.0]
```

On the other hand,

```julia
julia> dest[:,:] = src[:,:]
julia> print(dest)
[0.0 0.0]
julia> print(dest_)
[1.0, 0.0, 0.0, 4.0]
```

Even though `vec(dest.parent)` points to the same data as `dest_`, it's actually a `SubArray`, so storing it in the `data` field of `StridedData` creates a new vector with fresh storage. Changes to this new vector are then not propagated to the original vector. For example,

```julia
julia> using TensorOperations
julia> x_ = collect(1.0:4.0)
julia> x = reshape(view(x_, 2:3), 1, 2)
julia> xSD = TensorOperations.StridedData(x)
julia> pointer(x_)
Ptr{Float64} @0x00007fec6831e5f0
julia> pointer(x)
Ptr{Float64} @0x00007fec6831e5f8
julia> pointer(xSD.data)
Ptr{Float64} @0x00007fec674bd2b0
julia> xSD.data[2] = 9.0
9.0
julia> print(x)
[2.0 3.0]
julia> print(x_)
[1.0, 2.0, 3.0, 4.0]
```

The attached patch addresses this by recursively unwrapping each layer of `reshape` and `view` until the plain underlying `Array` is reached. My understanding is that only the strides of the original array and the accumulated offsets from all the views are necessary for addressing into the underlying array, so this is how I've implemented it. However, I'm not very familiar with these aspects of the language, so I may have overlooked something.