### PR TITLE
Update for Julia 1.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,16 +4,15 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
   - 0.7
+  - 1.0
   - nightly
 notifications:
   email: false
 
 matrix:
- allow_failures:
- - julia: 0.7
- - julia: nightly
+  allow_failures:
+  - julia: nightly
 
 after_success:
   # push coverage results to Coveralls and Codecov

--- a/README.md
+++ b/README.md
@@ -10,11 +10,11 @@ Fast tensor operations using a convenient index notation.
 - The `@tensor` macro will reorganize the contraction order of the so-called NCON style of specifying indices is respected, i.e. all contracted indices are labelled by positive integers and all uncontracted indices are specified by negative integers. In that case, tensors will be contracted in such an order that indices with smaller integer label will
 be contracted first
 - Better overall type stability, both in the `@tensor(opt)` environment and with the function based approach. Even the simple function based syntax can now be made type stable by specifing the indices using tuples.
-- Fully compatible with Julia v0.6 (v0.5 no longer supported); compatible (but with deprecation warnings) with julia v0.7-rc1.
+- Fully compatible with Julia v0.7/v1.0 (v0.6 no longer supported).
 
 ## Installation
 
-Install with the package manager, `Pkg.add("TensorOperations")`
+Install with the package manager, `pkg> add TensorOperations`.
 
 ## Philosophy
 

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,1 @@
-julia 0.6
-Compat 1.0.0
+julia 0.7

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,9 +1,16 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.5/julia-0.5-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.5/julia-0.5-latest-win64.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
-  - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
+  - julia_version: 0.7
+  - julia_version: 1
+  - julia_version: nightly
+
+platform:
+  - x86
+  - x64
+
+matrix:
+  allow_failures:
+  - julia_version: nightly
 
 branches:
   only:
@@ -17,19 +24,13 @@ notifications:
     on_build_status_changed: false
 
 install:
-  - ps: "[System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12"
-# Download most recent Julia Windows binary
-  - ps: (new-object net.webclient).DownloadFile(
-        $env:JULIA_URL,
-        "C:\projects\julia-binary.exe")
-# Run installer silently, output to C:\projects\julia
-  - C:\projects\julia-binary.exe /S /D=C:\projects\julia
+  - ps: iex ((new-object net.webclient).DownloadString("https://raw.githubusercontent.com/JuliaCI/Appveyor.jl/version-1/bin/install.ps1"))
 
 build_script:
-# Need to convert from shallow to complete for Pkg.clone to work
-  - IF EXIST .git\shallow (git fetch --unshallow)
-  - C:\projects\julia\bin\julia -e "versioninfo();
-      Pkg.clone(pwd(), \"TensorOperations\"); Pkg.build(\"TensorOperations\")"
+  - echo "%JL_BUILD_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_BUILD_SCRIPT%"
 
 test_script:
-  - C:\projects\julia\bin\julia -e "Pkg.test(\"TensorOperations\")"
+  - echo "%JL_TEST_SCRIPT%"
+  - C:\julia\bin\julia -e "%JL_TEST_SCRIPT%"
+

--- a/src/TensorOperations.jl
+++ b/src/TensorOperations.jl
@@ -21,9 +21,6 @@ _findnext(args...) = (i = findnext(args...); isa(i, Nothing) ? 0 : i)
 _findlast(args...) = (i = findlast(args...); isa(i, Nothing) ? 0 : i)
 
 
-using Compat
-using Compat: copyto!
-
 export tensorcopy, tensoradd, tensortrace, tensorcontract, tensorproduct, scalar
 export tensorcopy!, tensoradd!, tensortrace!, tensorcontract!, tensorproduct!
 


### PR DESCRIPTION
This updates TensorOperations fully for Julia 0.7/1.0 but drops support for 0.6 as the new iteration protocol is not supported in 0.6 nor in Compat. Cosequently this also drops the dependency on Compat. The README and CI scripts have been updated as well.