### PR TITLE
Add code example to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,23 @@ breaking changes, especially in the function syntax.
 
 [coveralls-img]: https://coveralls.io/repos/github/Jutho/TensorOperations.jl/badge.svg?branch=master
 [coveralls-url]: https://coveralls.io/github/Jutho/TensorOperations.jl
+
+
+### Code Example
+
+TensorOperations.jl is mostly used through the `@tensor` macro which allows one to express a given operation in terms of [index notation](https://en.wikipedia.org/wiki/Abstract_index_notation) format, a.k.a. [Einstein notation](https://en.wikipedia.org/wiki/Einstein_notation) (using Einstein's summation convention).
+```julia
+using TensorOperations
+α=randn()
+A=randn(5,5,5,5,5,5)
+B=randn(5,5,5)
+C=randn(5,5,5)
+D=zeros(5,5,5)
+@tensor begin
+    D[a,b,c] = A[a,e,f,c,f,g]*B[g,b,e] + α*C[c,a,b]
+    E[a,b,c] := A[a,e,f,c,f,g]*B[g,b,e] + α*C[c,a,b]
+end
+```
+In the second to last line, the result of the operation will be stored in the preallocated array `D`, whereas the last line uses a different assignment operator `:=` in order to define and allocate a new array `E` of the correct size. The contents of `D` and `E` will be equal.
+
+For more information, please see the docs. 


### PR DESCRIPTION
Personally, when I visit a package repo I want to see at least some simple code examples right away. Currently, one has to first navigate to the docs, and then from the main docs page to the 'Index notation with `@tensor` macro' before they ever see an example of what using TensorOperations.jl might look like in their code.

This PR adds adds the demo from the docs to the REAME so that potential users can see what an awesome package this is right from the start.

If it was a conscious choice to have a spartan README, thats fine and feel free to close this PR, but I think a lot of people prefer to at least see a quick code example before going to the docs. 