### PR TITLE
A more helpful error message when splatting into @ncon.

### DIFF
--- a/src/indexnotation/tensormacros.jl
+++ b/src/indexnotation/tensormacros.jl
@@ -184,6 +184,9 @@ function _nconmacro(tensors, indices, kwargs = nothing)
     else
         throw(ArgumentError("invalid @ncon syntax"))
     end
+    if any(isa(ta, Expr) && ta.head === :... for ta in tensorargs)
+        throw(ArgumentError("@ncon does not support splats (...) in tensor lists."))
+    end
     conjlist = fill(false, length(tensorargs))
     for i = 1:length(tensorargs)
         if tensorargs[i] isa Expr


### PR DESCRIPTION
Resolves https://github.com/Jutho/TensorOperations.jl/issues/79

I considered, instead of just checking that there aren't splats in `tensorlist`, enforcing that all elements should be symbols or calls to `conj`. I didn't dare do that for fear of excluding some use case I hadn't thought of.