### PR TITLE
Support to specify index costs together by tuple

### DIFF
--- a/src/indexnotation/optdata.jl
+++ b/src/indexnotation/optdata.jl
@@ -11,37 +11,35 @@ function optdata(optex::Expr, ex::Expr)
         if all(x -> isa(x, Expr) && x.head == :call && x.args[1] == :(=>), args)
             indices = Vector{Any}()
             costs = Vector{Any}()
-            costtype = typeof(parsecost(args[1].args[3]))
             for a in args
                 if typeof(a.args[2]) != Symbol && a.args[2].head == :tuple
                     for b in a.args[2].args
                         push!(indices, normalizeindex(b))
                         push!(costs, parsecost(a.args[3]))
-                        costtype = promote_type(costtype, typeof(costs[end]))
                     end
                 else
                     push!(indices, normalizeindex(a.args[2]))
                     push!(costs, parsecost(a.args[3]))
-                    costtype = promote_type(costtype, typeof(costs[end]))
                 end
             end
+            costtype = promote_type(typeof.(costs)...)
+            costs = convert(Vector{costtype}, costs)
         elseif all(x -> isa(x, Expr) && x.head == :(=), args)
             indices = Vector{Any}()
             costs = Vector{Any}()
-            costtype = typeof(parsecost(args[1].args[2]))
             for a in args
                 if typeof(a.args[1]) != Symbol && a.args[1].head == :tuple
                     for b in a.args[1].args
                         push!(indices, normalizeindex(b))
                         push!(costs, parsecost(a.args[2]))
-                        costtype = promote_type(costtype, typeof(costs[end]))
                     end
                 else
                     push!(indices, normalizeindex(a.args[1]))
                     push!(costs, parsecost(a.args[2]))
-                    costtype = promote_type(costtype, typeof(costs[end]))
                 end
             end
+            costtype = promote_type(typeof.(costs)...)
+            costs = convert(Vector{costtype}, costs)
         else
             indices = map(normalizeindex, args)
             costtype = Power{:χ,Int}

--- a/src/indexnotation/optdata.jl
+++ b/src/indexnotation/optdata.jl
@@ -25,6 +25,23 @@ function optdata(optex::Expr, ex::Expr)
                     costtype = promote_type(costtype, typeof(costs[end]))
                 end
             end
+        elseif all(x -> isa(x, Expr) && x.head == :(=), args)
+            indices = Vector{Any}()
+            costs = Vector{Any}()
+            costtype = typeof(parsecost(args[1].args[2]))
+            for a in args
+                if typeof(a.args[1]) != Symbol && a.args[1].head == :tuple
+                    for b in a.args[1].args
+                        push!(indices, normalizeindex(b))
+                        push!(costs, parsecost(a.args[2]))
+                        costtype = promote_type(costtype, typeof(costs[end]))
+                    end
+                else
+                    push!(indices, normalizeindex(a.args[1]))
+                    push!(costs, parsecost(a.args[2]))
+                    costtype = promote_type(costtype, typeof(costs[end]))
+                end
+            end
         else
             indices = map(normalizeindex, args)
             costtype = Power{:χ,Int}

--- a/src/indexnotation/optdata.jl
+++ b/src/indexnotation/optdata.jl
@@ -47,7 +47,7 @@ function optdata(optex::Expr, ex::Expr)
             costtype = Power{:χ,Int}
             costs = fill(Power{:χ,Int}(1,1), length(args))
         end
-        return Dict{Any, costtype}(indices[k]=>costs[k] for k = 1:length(args))
+        return Dict{Any, costtype}(k=>v for (k,v) in zip(indices, costs))
     elseif optex.head == :call && optex.args[1] == :!
         allindices = unique(getallindices(ex))
         excludeind = map(normalizeindex, optex.args[2:end])

--- a/test/tensor.jl
+++ b/test/tensor.jl
@@ -281,6 +281,23 @@ withcache = TensorOperations.use_cache() ? "with" : "without"
         @tensoropt ((a,d)=>χ,b=>χ^2,(c,f)=>2*χ,e=>5) D3[a,b,c,d] := A[a,e,c,f]*B[g,d,e]*C[g,f,b]
         @tensoropt ((a,d)=χ,b=χ^2,(c,f)=2*χ,e=5) D4[a,b,c,d] := A[a,e,c,f]*B[g,d,e]*C[g,f,b]
         @test D1 == D2 == D3 == D4
+        _optdata = optex -> TensorOperations.optdata(optex, :(D1[a,b,c,d] := A[a,e,c,f]*B[g,d,e]*C[g,f,b]))
+        optex1 = :((a=>χ,b=>χ^2,c=>2*χ,d=>χ,e=>5,f=>2*χ))
+        optex2 = :((a=χ,b=χ^2,c=2*χ,d=χ,e=5,f=2*χ))
+        optex3 = :(((a,d)=>χ,b=>χ^2,(c,f)=>2*χ,e=>5))
+        optex4 = :(((a,d)=χ,b=χ^2,(c,f)=2*χ,e=5))
+        optex5 = :(((a,)=>χ,b=>χ^2,(c,)=>2χ,d=>χ,e=>5,f=>χ*2,()=>12345))
+        @test _optdata(optex1) == _optdata(optex2) == _optdata(optex3) == _optdata(optex4) == _optdata(optex5)
+        optex6 = :(((a,b,c)=χ,))
+        optex7 = :((a,b,c))
+        @test _optdata(optex6) == _optdata(optex7)
+        optex8 = :(((a,b,c)=1,(d,e,f,g)=χ))
+        optex9 = :(!(a,b,c))
+        @test _optdata(optex8) == _optdata(optex9)
+        optex10 = :((a=>χ,b=>χ^2,c=2*χ,d=>χ,e=>5,f=2*χ))
+        optex11 = :((a=χ,b=χ^2,c=2*χ,d,e=5,f))
+        @test_throws ErrorException _optdata(optex10)
+        @test_throws ErrorException _optdata(optex11)
     end
 
     @testset "Issue 83" begin

--- a/test/tensor.jl
+++ b/test/tensor.jl
@@ -272,6 +272,17 @@ withcache = TensorOperations.use_cache() ? "with" : "without"
     println("tensor network examples: $(time()-t0) seconds")
     t0 = time()
 
+    @testset "tensoropt" begin
+        A=randn(5,5,5,5)
+        B=randn(5,5,5)
+        C=randn(5,5,5)
+        @tensoropt (a=>χ,b=>χ^2,c=>2*χ,d=>χ,e=>5,f=>2*χ) D1[a,b,c,d] := A[a,e,c,f]*B[g,d,e]*C[g,f,b]
+        @tensoropt (a=χ,b=χ^2,c=2*χ,d=χ,e=5,f=2*χ) D2[a,b,c,d] := A[a,e,c,f]*B[g,d,e]*C[g,f,b]
+        @tensoropt ((a,d)=>χ,b=>χ^2,(c,f)=>2*χ,e=>5) D3[a,b,c,d] := A[a,e,c,f]*B[g,d,e]*C[g,f,b]
+        @tensoropt ((a,d)=χ,b=χ^2,(c,f)=2*χ,e=5) D4[a,b,c,d] := A[a,e,c,f]*B[g,d,e]*C[g,f,b]
+        @test D1 == D2 == D3 == D4
+    end
+
     @testset "Issue 83" begin
         op1 = randn(2, 2)
         op2 = randn(2, 2)


### PR DESCRIPTION
This pull request make it possible to write codes with `@tensoropt` macro like
```julia
@tensoropt (a=>χ,b=>χ^2,c=>2*χ,d=>χ,e=>5,f=>2*χ) D1[a,b,c,d] := A[a,e,c,f]*B[g,d,e]*C[g,f,b]
```
shorter and clearer, by using tuple:
```julia
@tensoropt ((a,d)=>χ,b=>χ^2,(c,f)=>2*χ,e=>5) D3[a,b,c,d] := A[a,e,c,f]*B[g,d,e]*C[g,f,b]
```

It also enable us to use `=` instead of `=>`:
```julia
@tensoropt (a=χ,b=χ^2,c=2*χ,d=χ,e=5,f=2*χ) D2[a,b,c,d] := A[a,e,c,f]*B[g,d,e]*C[g,f,b]
@tensoropt ((a,d)=χ,b=χ^2,(c,f)=2*χ,e=5) D4[a,b,c,d] := A[a,e,c,f]*B[g,d,e]*C[g,f,b]
```


