### PR TITLE
cache also uses taskid

### DIFF
--- a/src/TensorOperations.jl
+++ b/src/TensorOperations.jl
@@ -105,7 +105,7 @@ end
 memsize(a::Array) = sizeof(a)
 memsize(a) = Base.summarysize(a)
 
-const cache = LRU{Tuple{Symbol,Int}, Any}(; by = memsize, maxsize = default_cache_size())
+const cache = LRU{Tuple{Symbol,Int,UInt64}, Any}(; by = memsize, maxsize = default_cache_size())
 const _use_cache = Ref(true)
 use_cache() = _use_cache[]
 

--- a/src/implementation/tensorcache.jl
+++ b/src/implementation/tensorcache.jl
@@ -3,7 +3,7 @@ similar_from_indices(T::Type, p1::IndexTuple, p2::IndexTuple, A, CA::Symbol) =
 
 function cached_similar_from_indices(sym::Symbol, T::Type, p1::IndexTuple, p2::IndexTuple, A, CA::Symbol)
     if use_cache()
-        key = (sym, Threads.threadid())
+        key = (sym, Threads.threadid(),objectid(current_task()))
         C = get(cache, key, nothing)
         C′ = checked_similar_from_indices(C, T, p1, p2, A, CA)
         cache[key] = C′
@@ -20,7 +20,7 @@ function cached_similar_from_indices(sym::Symbol, T::Type, poA::IndexTuple, poB:
     p1::IndexTuple, p2::IndexTuple, A, B, CA::Symbol, CB::Symbol)
 
     if use_cache()
-        key = (sym, Threads.threadid())
+        key = (sym, Threads.threadid(),objectid(current_task()))
         C = get(cache, key, nothing)
         C′ = checked_similar_from_indices(C, T, poA, poB, p1, p2, A, B, CA, CB)
         cache[key] = C′


### PR DESCRIPTION
The caching mechanism appeared to fail with multiple tasks running on the same thread. 

If you used tensoroperations in conjunction with strided and the new multithreading capabilities, a race condition was possible. Strided had a @threads for, which causes the scheduler sometimes to yield execution to another coroutine on the same thread (and therefore initially not actually executing the matrix multiplication). This coroutine would then acquire the same caches. Then, when the matrix multiplication actually got done in place, it would overwrite the result for both coroutines.

A minimal example demonstrating this behaviour independent of tensoroperations/strided is attached.
[minimal.zip](https://github.com/Jutho/TensorOperations.jl/files/4694202/minimal.zip)

