### PR TITLE
Several tweaks to the CI configuration

### DIFF
--- a/.github/workflows/ci-julia-nightly.yml
+++ b/.github/workflows/ci-julia-nightly.yml
@@ -1,4 +1,4 @@
-name: CI
+name: CI (Julia nightly)
 on:
   - push
   - pull_request
@@ -10,8 +10,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.4'
-          - '1' # automatically expands to the latest stable 1.x release of Julia
+          - 'nightly'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Fast tensor operations using a convenient Einstein index notation.
 
 | **Documentation**                                                               | **Build Status**                                                                                | **Digital Object Identifier**  |
 |:-------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------:|:-----------------------------------------------------------------------------------------------:|
-| [![][docs-stable-img]][docs-stable-url] [![][docs-dev-img]][docs-dev-url] | [![CI][github-img]][github-url] [![][codecov-img]][codecov-url] | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3245497.svg)](https://doi.org/10.5281/zenodo.3245497) |
+| [![][docs-stable-img]][docs-stable-url] [![][docs-dev-img]][docs-dev-url] | [![CI][ci-img]][ci-url] [![CI (Julia nightly)][ci-julia-nightly-img]][ci-julia-nightly-url] [![][codecov-img]][codecov-url] | [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.3245497.svg)](https://doi.org/10.5281/zenodo.3245497) |
 
 [docs-dev-img]: https://img.shields.io/badge/docs-dev-blue.svg
 [docs-dev-url]: https://jutho.github.io/TensorOperations.jl/latest
@@ -14,6 +14,12 @@ Fast tensor operations using a convenient Einstein index notation.
 
 [github-img]: https://github.com/Jutho/TensorOperations.jl/workflows/CI/badge.svg
 [github-url]: https://github.com/Jutho/TensorOperations.jl/actions?query=workflow%3ACI
+
+[ci-img]: https://github.com/Jutho/TensorOperations.jl/workflows/CI/badge.svg
+[ci-url]: https://github.com/Jutho/TensorOperations.jl/actions?query=workflow%3ACI
+
+[ci-julia-nightly-img]: https://github.com/Jutho/TensorOperations.jl/workflows/CI%20(Julia%20nightly)/badge.svg
+[ci-julia-nightly-url]: https://github.com/Jutho/TensorOperations.jl/actions?query=workflow%3A%22CI+%28Julia+nightly%29%22
 
 [codecov-img]: https://codecov.io/gh/Jutho/TensorOperations.jl/branch/master/graph/badge.svg
 [codecov-url]: https://codecov.io/gh/Jutho/TensorOperations.jl


### PR DESCRIPTION
This pull request makes the following modifications to the CI configuration:
1. Replaces `'1.5'` with `'1'`. `'1'` will always expand to the latest stable 1.x release of Julia. Therefore, when a new 1.x release comes out, this ensures that CI will always uses the latest Julia 1.x.
2. Use the official Codecov action to submit code coverage. When using the official Codecov action, no token is necessary. This allows code coverage to be submitted from PRs made from forks.
3. Separate the CI for Julia nightly into a separate workflow file. This allows the status of CI on Julia 1.x to be tracked separately from the status of CI on Julia nightly. Therefore, if CI fails on Julia nightly, the CI badge in the README will still say "passing". However, it is still very easy to see, at a glance, that CI is failing on Julia nightly. This is more robust than the current approach on `master`, which uses `continue-on-error: ${{ matrix.version == 'nightly' }}`. When using `continue-on-error`, it is very easy to miss failures on nightly.