### PR TITLE
Fix link to LRUCache in docs

### DIFF
--- a/docs/src/cache.md
+++ b/docs/src/cache.md
@@ -19,8 +19,7 @@ The `@tensor` macro expands the given expression and immediately generates the c
 create the necessary temporaries. It associates with each of them a random symbol
 (`gensym()`) and uses this as an identifier (together with the `Threads.threadid` of where it it is being evaluated) in a package wide global cache structure
 `TensorOperations.cache`, the implementation of which is a least-recently used cache
-dictionary from [LRUCache.jl](https://github.com/JuliaCollections/
-LRUCache.jl). Thereto, it estimates the size of each object added to the cache
+dictionary from [LRUCache.jl](https://github.com/JuliaCollections/LRUCache.jl). Thereto, it estimates the size of each object added to the cache
 using `Base.summarysize` and discards objects once a certain memory limit is reached.
 
 ## Enabling and disabling the cache


### PR DESCRIPTION
There was a space in the URL which make the link not work. That's fixed in this PR.