### PR TITLE
Automatic Differentiation test rewrite

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -37,12 +37,12 @@ julia = "1.6"
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
+ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"
 DynamicPolynomials = "7c1d4256-1411-5781-91ec-d7bc3513ac07"
 Logging = "56ddb016-857b-54e1-b83d-db4d58db5568"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
-Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 cuTENSOR = "011b41b2-24ef-40a8-b3eb-fa098493e9e1"
 
 [targets]
-test = ["Test", "Random", "DynamicPolynomials", "Zygote", "CUDA", "cuTENSOR", "Aqua", "Logging"]
+test = ["Test", "Random", "DynamicPolynomials", "ChainRulesTestUtils", "CUDA", "cuTENSOR", "Aqua", "Logging"]

--- a/ext/TensorOperationsChainRulesCoreExt.jl
+++ b/ext/TensorOperationsChainRulesCoreExt.jl
@@ -22,6 +22,14 @@ trivtuple(N) = ntuple(identity, N)
 
 # TODO: possibly use the non-inplace functions, to avoid depending on Base.copy
 
+function ChainRulesCore.rrule(::typeof(tensorscalar), C)
+    function tensorscalar_pullback(Δc)
+        ΔC = TensorOperations.tensoralloc(typeof(C), TensorOperations.tensorstructure(C))
+        return NoTangent(), fill!(ΔC, unthunk(Δc))
+    end
+    return tensorscalar(C), tensorscalar_pullback
+end
+
 function ChainRulesCore.rrule(::typeof(TensorOperations.tensoradd!),
                               C, pC::Index2Tuple,
                               A, conjA::Symbol,

--- a/ext/TensorOperationsChainRulesCoreExt.jl
+++ b/ext/TensorOperationsChainRulesCoreExt.jl
@@ -33,7 +33,8 @@ function ChainRulesCore.rrule(::typeof(TensorOperations.tensoradd!),
     projectα = ProjectTo(α)
     projectβ = ProjectTo(β)
 
-    function pullback(ΔC)
+    function pullback(ΔC′)
+        ΔC = unthunk(ΔC′)
         dC = @thunk projectC(scale(ΔC, conj(β)))
         dA = @thunk begin
             ipC = invperm(linearize(pC))
@@ -76,7 +77,8 @@ function ChainRulesCore.rrule(::typeof(TensorOperations.tensorcontract!),
     projectα = ProjectTo(α)
     projectβ = ProjectTo(β)
 
-    function pullback(ΔC)
+    function pullback(ΔC′)
+        ΔC = unthunk(ΔC′)
         ipC = invperm(linearize(pC))
         pΔC = (TupleTools.getindices(ipC, trivtuple(numout(pA))),
                TupleTools.getindices(ipC, numout(pA) .+ trivtuple(numin(pB))))
@@ -141,7 +143,8 @@ function ChainRulesCore.rrule(::typeof(tensortrace!), C, pC::Index2Tuple, A,
     projectα = ProjectTo(α)
     projectβ = ProjectTo(β)
 
-    function pullback(ΔC)
+    function pullback(ΔC′)
+        ΔC = unthunk(ΔC′)
         dC = @thunk projectC(scale(ΔC, conj(β)))
         dA = @thunk begin
             ipC = invperm((linearize(pC)..., pA[1]..., pA[2]...))


### PR DESCRIPTION
Rewrites the tests for AD with the help of `ChainRulesTestUtils`.

Also fixes some rrules when arguments are thunked, and adds a rrule for tensorscalar