### PR TITLE
Switch up argument order

### DIFF
--- a/ext/TensorOperationsChainRulesCoreExt.jl
+++ b/ext/TensorOperationsChainRulesCoreExt.jl
@@ -65,7 +65,7 @@ function ChainRulesCore.rrule(::typeof(TensorOperations.tensoradd!),
         end
         dα = @thunk begin
             _dα = tensorscalar(tensorcontract(A, ((), linearize(pA)), _conj(conjA),
-                                              C, (trivtuple(numind(pA)), ()), :N,
+                                              ΔC, (trivtuple(numind(pA)), ()), :N,
                                               ((), ()), One(), backend...))
             return projectα(_dα)
         end

--- a/ext/TensorOperationsChainRulesCoreExt.jl
+++ b/ext/TensorOperationsChainRulesCoreExt.jl
@@ -43,10 +43,10 @@ function ChainRulesCore.rrule(::typeof(tensorscalar), C)
 end
 
 function ChainRulesCore.rrule(::typeof(TensorOperations.tensoradd!),
-                              C, pC::Index2Tuple,
-                              A, conjA::Symbol,
+                              C,
+                              A, pA::Index2Tuple, conjA::Symbol,
                               α::Number, β::Number, backend::Backend...)
-    C′ = tensoradd!(copy(C), pC, A, conjA, α, β, backend...)
+    C′ = tensoradd!(copy(C), A, pA, conjA, α, β, backend...)
 
     projectA = ProjectTo(A)
     projectC = ProjectTo(C)
@@ -57,23 +57,23 @@ function ChainRulesCore.rrule(::typeof(TensorOperations.tensoradd!),
         ΔC = unthunk(ΔC′)
         dC = @thunk projectC(scale(ΔC, conj(β)))
         dA = @thunk begin
-            ipC = invperm(linearize(pC))
+            ipA = invperm(linearize(pA))
             _dA = zerovector(A, VectorInterface.promote_add(ΔC, α))
-            _dA = tensoradd!(_dA, (ipC, ()), ΔC, conjA, conjA == :N ? conj(α) : α, Zero(),
+            _dA = tensoradd!(_dA, (ipA, ()), ΔC, conjA, conjA == :N ? conj(α) : α, Zero(),
                              backend...)
             return projectA(_dA)
         end
         dα = @thunk begin
-            _dα = tensorscalar(tensorcontract(((), ()), A, ((), linearize(pC)),
+            _dα = tensorscalar(tensorcontract(((), ()), A, ((), linearize(pA)),
                                               _conj(conjA), ΔC,
-                                              (trivtuple(numind(pC)),
+                                              (trivtuple(numind(pA)),
                                                ()), :N, One(), backend...))
             return projectα(_dα)
         end
         dβ = @thunk begin
             _dβ = tensorscalar(tensorcontract(((), ()), C,
-                                              ((), trivtuple(numind(pC))), :C, ΔC,
-                                              (trivtuple(numind(pC)), ()), :N, One(),
+                                              ((), trivtuple(numind(pA))), :C, ΔC,
+                                              (trivtuple(numind(pA)), ()), :N, One(),
                                               backend...))
             return projectβ(_dβ)
         end
@@ -85,11 +85,12 @@ function ChainRulesCore.rrule(::typeof(TensorOperations.tensoradd!),
 end
 
 function ChainRulesCore.rrule(::typeof(TensorOperations.tensorcontract!),
-                              C, pC::Index2Tuple,
+                              C,
                               A, pA::Index2Tuple, conjA::Symbol,
                               B, pB::Index2Tuple, conjB::Symbol,
+                              pAB::Index2Tuple,
                               α::Number, β::Number, backend::Backend...)
-    C′ = tensorcontract!(copy(C), pC, A, pA, conjA, B, pB, conjB, α, β, backend...)
+    C′ = tensorcontract!(copy(C), A, pA, conjA, B, pB, conjB, pAB, α, β, backend...)
 
     projectA = ProjectTo(A)
     projectB = ProjectTo(B)
@@ -99,18 +100,19 @@ function ChainRulesCore.rrule(::typeof(TensorOperations.tensorcontract!),
 
     function pullback(ΔC′)
         ΔC = unthunk(ΔC′)
-        ipC = invperm(linearize(pC))
-        pΔC = (TupleTools.getindices(ipC, trivtuple(numout(pA))),
-               TupleTools.getindices(ipC, numout(pA) .+ trivtuple(numin(pB))))
+        ipAB = invperm(linearize(pAB))
+        pΔC = (TupleTools.getindices(ipAB, trivtuple(numout(pA))),
+               TupleTools.getindices(ipAB, numout(pA) .+ trivtuple(numin(pB))))
         dC = @thunk projectC(scale(ΔC, conj(β)))
         dA = @thunk begin
             ipA = (invperm(linearize(pA)), ())
             conjΔC = conjA == :C ? :C : :N
             conjB′ = conjA == :C ? conjB : _conj(conjB)
             _dA = zerovector(A, promote_contract(scalartype(ΔC), scalartype(B), typeof(α)))
-            _dA = tensorcontract!(_dA, ipA,
+            _dA = tensorcontract!(_dA,
                                   ΔC, pΔC, conjΔC,
                                   B, reverse(pB), conjB′,
+                                  ipA,
                                   conjA == :C ? α : conj(α), Zero(), backend...)
             return projectA(_dA)
         end
@@ -119,9 +121,10 @@ function ChainRulesCore.rrule(::typeof(TensorOperations.tensorcontract!),
             conjΔC = conjB == :C ? :C : :N
             conjA′ = conjB == :C ? conjA : _conj(conjA)
             _dB = zerovector(B, promote_contract(scalartype(ΔC), scalartype(A), typeof(α)))
-            _dB = tensorcontract!(_dB, ipB,
+            _dB = tensorcontract!(_dB,
                                   A, reverse(pA), conjA′,
                                   ΔC, pΔC, conjΔC,
+                                  ipB,
                                   conjB == :C ? α : conj(α), Zero(), backend...)
             return projectB(_dB)
         end
@@ -143,8 +146,9 @@ function ChainRulesCore.rrule(::typeof(TensorOperations.tensorcontract!),
             return projectβ(_dβ)
         end
         dbackend = map(x -> NoTangent(), backend)
-        return NoTangent(), dC, NoTangent(),
-               dA, NoTangent(), NoTangent(), dB, NoTangent(), NoTangent(), dα, dβ,
+        return NoTangent(), dC,
+               dA, NoTangent(), NoTangent(), dB, NoTangent(), NoTangent(), NoTangent(),
+               dα, dβ,
                dbackend...
     end
 
@@ -153,10 +157,10 @@ end
 
 # note that this requires `one` to be defined, which is already not the case for regular
 # arrays when tracing multiple indices at the same time.
-function ChainRulesCore.rrule(::typeof(tensortrace!), C, pC::Index2Tuple, A,
-                              pA::Index2Tuple, conjA::Symbol, α::Number, β::Number,
-                              backend::Backend...)
-    C′ = tensortrace!(copy(C), pC, A, pA, conjA, α, β, backend...)
+function ChainRulesCore.rrule(::typeof(tensortrace!), C,
+                              A, p::Index2Tuple, q::Index2Tuple, conjA::Symbol,
+                              α::Number, β::Number, backend::Backend...)
+    C′ = tensortrace!(copy(C), A, p, q, conjA, α, β, backend...)
 
     projectA = ProjectTo(A)
     projectC = ProjectTo(C)
@@ -167,36 +171,36 @@ function ChainRulesCore.rrule(::typeof(tensortrace!), C, pC::Index2Tuple, A,
         ΔC = unthunk(ΔC′)
         dC = @thunk projectC(scale(ΔC, conj(β)))
         dA = @thunk begin
-            ipC = invperm((linearize(pC)..., pA[1]..., pA[2]...))
-            Es = map(pA[1], pA[2]) do i1, i2
+            ip = invperm((linearize(p)..., q[1]..., q[2]...))
+            Es = map(q[1], q[2]) do i1, i2
                 return one(TensorOperations.tensoralloc_add(scalartype(A), ((i1,), (i2,)),
                                                             A, conjA))
             end
             E = _kron(Es, backend...)
             _dA = zerovector(A, VectorInterface.promote_scale(ΔC, α))
-            _dA = tensorproduct!(_dA, (ipC, ()), ΔC, (trivtuple(numind(pC)), ()), conjA, E,
-                                 ((), trivtuple(numind(pA))), conjA,
+            _dA = tensorproduct!(_dA, (ip, ()), ΔC, (trivtuple(numind(p)), ()), conjA, E,
+                                 ((), trivtuple(numind(q))), conjA,
                                  conjA == :N ? conj(α) : α, Zero(), backend...)
             return projectA(_dA)
         end
         dα = @thunk begin
             _dα = tensorscalar(tensorcontract(((), ()),
-                                              tensortrace(pC, A, pA),
-                                              ((), trivtuple(numind(pC))),
+                                              tensortrace(p, A, q),
+                                              ((), trivtuple(numind(p))),
                                               _conj(conjA), ΔC,
-                                              (trivtuple(numind(pC)), ()), :N, One(),
+                                              (trivtuple(numind(p)), ()), :N, One(),
                                               backend...))
             return projectα(_dα)
         end
         dβ = @thunk begin
             _dβ = tensorscalar(tensorcontract(((), ()), C,
-                                              ((), trivtuple(numind(pC))), :C, ΔC,
-                                              (trivtuple(numind(pC)), ()), :N, One(),
+                                              ((), trivtuple(numind(p))), :C, ΔC,
+                                              (trivtuple(numind(p)), ()), :N, One(),
                                               backend...))
             return projectβ(_dβ)
         end
         dbackend = map(x -> NoTangent(), backend)
-        return NoTangent(), dC, NoTangent(), dA, NoTangent(), NoTangent(), dα, dβ,
+        return NoTangent(), dC, dA, NoTangent(), NoTangent(), NoTangent(), dα, dβ,
                dbackend...
     end
 

--- a/ext/TensorOperationsChainRulesCoreExt.jl
+++ b/ext/TensorOperationsChainRulesCoreExt.jl
@@ -133,15 +133,14 @@ function ChainRulesCore.rrule(::typeof(TensorOperations.tensorcontract!),
                                   pAB, One(), backend...)
             # TODO: consider using `inner`
             _dα = tensorscalar(tensorcontract(Cnoβ, ((), trivtuple(numind(pAB))), :C,
-                                              ΔC, (trivtuple(numind(pC)), ()), :N,
+                                              ΔC, (trivtuple(numind(pAB)), ()), :N,
                                               ((), ()), One(), backend...))
             return projectα(_dα)
         end
         dβ = @thunk begin
             # TODO: consider using `inner`
-            _dβ = tensorscalar(tensorcontract(C,
-                                              ((), trivtuple(numind(pC))), :C,
-                                              ΔC, (trivtuple(numind(pC)), ()), :N,
+            _dβ = tensorscalar(tensorcontract(C, ((), trivtuple(numind(pAB))), :C,
+                                              ΔC, (trivtuple(numind(pAB)), ()), :N,
                                               ((), ()), One(), backend...))
             return projectβ(_dβ)
         end
@@ -172,8 +171,8 @@ function ChainRulesCore.rrule(::typeof(tensortrace!), C,
         dA = @thunk begin
             ip = invperm((linearize(p)..., q[1]..., q[2]...))
             Es = map(q[1], q[2]) do i1, i2
-                return one(TensorOperations.tensoralloc_add(scalartype(A), ((i1,), (i2,)),
-                                                            A, conjA))
+                return one(TensorOperations.tensoralloc_add(scalartype(A), A,
+                                                            ((i1,), (i2,)), conjA))
             end
             E = _kron(Es, backend...)
             _dA = zerovector(A, VectorInterface.promote_scale(ΔC, α))
@@ -184,16 +183,15 @@ function ChainRulesCore.rrule(::typeof(tensortrace!), C,
             return projectA(_dA)
         end
         dα = @thunk begin
-            _dα = tensorscalar(tensorcontract(tensortrace(p, A, q),
-                                              ((), trivtuple(numind(p))), _conj(conjA),
+            Cnoβ = tensortrace(A, p, q, :N, One(), backend...)
+            _dα = tensorscalar(tensorcontract(Cnoβ, ((), trivtuple(numind(p))), _conj(conjA),
                                               ΔC, (trivtuple(numind(p)), ()), :N,
                                               ((), ()), One(), backend...))
             return projectα(_dα)
         end
         dβ = @thunk begin
-            _dβ = tensorscalar(tensorcontract(C,
-                                              ((), trivtuple(numind(p))), :C, ΔC,
-                                              (trivtuple(numind(p)), ()), :N, 
+            _dβ = tensorscalar(tensorcontract(C, ((), trivtuple(numind(p))), :C, 
+                                              ΔC, (trivtuple(numind(p)), ()), :N,
                                               ((), ()), One(), backend...))
             return projectβ(_dβ)
         end

--- a/ext/TensorOperationsChainRulesCoreExt.jl
+++ b/ext/TensorOperationsChainRulesCoreExt.jl
@@ -128,11 +128,11 @@ function ChainRulesCore.rrule(::typeof(TensorOperations.tensorcontract!),
             return projectB(_dB)
         end
         dα = @thunk begin
-            Cnoβ = tensorcontract(A, pA, conjA,
+            C_αβ = tensorcontract(A, pA, conjA,
                                   B, pB, conjB,
                                   pAB, One(), backend...)
             # TODO: consider using `inner`
-            _dα = tensorscalar(tensorcontract(Cnoβ, ((), trivtuple(numind(pAB))), :C,
+            _dα = tensorscalar(tensorcontract(C_αβ, ((), trivtuple(numind(pAB))), :C,
                                               ΔC, (trivtuple(numind(pAB)), ()), :N,
                                               ((), ()), One(), backend...))
             return projectα(_dα)
@@ -183,14 +183,15 @@ function ChainRulesCore.rrule(::typeof(tensortrace!), C,
             return projectA(_dA)
         end
         dα = @thunk begin
-            Cnoβ = tensortrace(A, p, q, :N, One(), backend...)
-            _dα = tensorscalar(tensorcontract(Cnoβ, ((), trivtuple(numind(p))), _conj(conjA),
+            C_αβ = tensortrace(A, p, q, :N, One(), backend...)
+            _dα = tensorscalar(tensorcontract(C_αβ, ((), trivtuple(numind(p))),
+                                              _conj(conjA),
                                               ΔC, (trivtuple(numind(p)), ()), :N,
                                               ((), ()), One(), backend...))
             return projectα(_dα)
         end
         dβ = @thunk begin
-            _dβ = tensorscalar(tensorcontract(C, ((), trivtuple(numind(p))), :C, 
+            _dβ = tensorscalar(tensorcontract(C, ((), trivtuple(numind(p))), :C,
                                               ΔC, (trivtuple(numind(p)), ()), :N,
                                               ((), ()), One(), backend...))
             return projectβ(_dβ)

--- a/src/implementation/abstractarray.jl
+++ b/src/implementation/abstractarray.jl
@@ -96,41 +96,41 @@ function argcheck_index2tuple(C::AbstractArray, pC::Index2Tuple)
 end
 
 """
-    argcheck_tensoradd(C::AbstractArray, pC::Index2Tuple, A::AbstractArray)
+    argcheck_tensoradd(C::AbstractArray, A::AbstractArray, pA::Index2Tuple)
 
-Check that `C` and `A` have `numind(pC)` indices and that `pC` constitutes a valid permutation.
+Check that `C` and `A` have `numind(pA)` indices and that `pA` constitutes a valid permutation.
 """
-function argcheck_tensoradd(C::AbstractArray, pC::Index2Tuple, A::AbstractArray)
+function argcheck_tensoradd(C::AbstractArray, A::AbstractArray, pA::Index2Tuple)
     ndims(C) == ndims(A) || throw(IndexError("non-matching number of dimensions"))
-    argcheck_index2tuple(C, pC)
+    argcheck_index2tuple(A, pA)
     return nothing
 end
 
 """
-    argcheck_tensortrace(C::AbstractArray, pC::Index2Tuple, A::AbstractArray, pA::Index2Tuple)
+    argcheck_tensortrace(C::AbstractArray, A::AbstractArray, p::Index2Tuple, q::Index2Tuple)
 
-Check that `C` and `pC` have compatible indices and number of dimensions with the trace of
-`A` over indices `pA`.
+Check that `C` has compatible indices and number of dimensions with the trace of
+`A` over indices `p` and.
 """
-function argcheck_tensortrace(C::AbstractArray, pC::Index2Tuple, A::AbstractArray,
-                              pA::Index2Tuple)
-    ndims(C) == numind(pC) ||
-        throw(IndexError("invalid selection of length $(ndims(C)): $pC"))
-    2 * numin(pA) == 2 * numout(pA) == ndims(A) - ndims(C) ||
+function argcheck_tensortrace(C::AbstractArray, A::AbstractArray, p::Index2Tuple, q::Index2Tuple)
+    ndims(C) == numind(p) ||
+        throw(IndexError("invalid selection of length $(ndims(C)): $p"))
+    2 * numin(q) == 2 * numout(q) == ndims(A) - ndims(C) ||
         throw(IndexError("invalid number of trace dimensions"))
     return nothing
 end
 
 """
-    argcheck_tensorcontract(C::AbstractArray, pC::Index2Tuple, A::AbstractArray, pA::Index2Tuple, B::AbstractArray, pB::Index2Tuple)
+    argcheck_tensorcontract(C::AbstractArray, A::AbstractArray, pA::Index2Tuple, B::AbstractArray, pB::Index2Tuple, pAB::Index2Tuple)
 
-Check that `C` and `pC`, `A` and `pA`, and `B` and `pB` have compatible indices and number
+Check that `C`, `A` and `pA`, and `B` and `pB` and `pAB` have compatible indices and number
 of dimensions.
 """
-function argcheck_tensorcontract(C::AbstractArray, pC::Index2Tuple,
+function argcheck_tensorcontract(C::AbstractArray,
                                  A::AbstractArray, pA::Index2Tuple,
-                                 B::AbstractArray, pB::Index2Tuple)
-    argcheck_index2tuple(C, pC)
+                                 B::AbstractArray, pB::Index2Tuple,
+                                 pAB::Index2Tuple)
+    argcheck_index2tuple(C, pAB)
     argcheck_index2tuple(A, pA)
     argcheck_index2tuple(B, pB)
     numout(pA) + numin(pB) == ndims(C) ||
@@ -141,45 +141,52 @@ function argcheck_tensorcontract(C::AbstractArray, pC::Index2Tuple,
 end
 
 """
-    dimcheck_tensoradd(C::AbstractArray, pC::Index2Tuple, A::AbstractArray)
+    dimcheck_tensoradd(C::AbstractArray, A::AbstractArray, pA::Index2Tuple)
 
-Check that `C` and `A` have compatible sizes for the addition specified by `pC`.
+Check that `C` and `A` have compatible sizes for the addition specified by `pA`.
 """
-function dimcheck_tensoradd(C::AbstractArray, pC::Index2Tuple, A::AbstractArray)
+function dimcheck_tensoradd(C::AbstractArray, A::AbstractArray, pA::Index2Tuple)
     szA, szC = size(A), size(C)
-    TupleTools.getindices(szA, linearize(pC)) == szC ||
+    TupleTools.getindices(szA, linearize(pA)) == szC ||
         throw(DimensionMismatch("non-matching sizes in uncontracted dimensions"))
     return nothing
 end
 
 """
-    dimcheck_tensorcontract(C::AbstractArray, pC::Index2Tuple, A::AbstractArray, pA::Index2Tuple)
+    dimcheck_tensorcontract(C::AbstractArray, A::AbstractArray,
+                            p::Index2Tuple, q::Index2Tuple)
 
-Check that `C` and `A` have compatible sizes for the trace and addition specified by `pC` and `pA`.
+Check that `C` and `A` have compatible sizes for the trace and addition specified by `p` and
+`q`.
 """
-function dimcheck_tensortrace(C::AbstractArray, pC::Index2Tuple, A::AbstractArray,
-                              pA::Index2Tuple)
+function dimcheck_tensortrace(C::AbstractArray, A::AbstractArray,
+                              p::Index2Tuple, q::Index2Tuple)
     szA, szC = size(A), size(C)
-    TupleTools.getindices(szA, pA[1]) == TupleTools.getindices(szA, pA[2]) ||
+    TupleTools.getindices(szA, q[1]) == TupleTools.getindices(szA, q[2]) ||
         throw(DimensionMismatch("non-matching sizes in traced dimensions"))
-    TupleTools.getindices(szA, linearize(pC)) == szC ||
+    TupleTools.getindices(szA, linearize(p)) == szC ||
         throw(DimensionMismatch("non-matching sizes in uncontracted dimensions"))
     return nothing
 end
 
 """
-    dimcheck_tensorcontract(C::AbstractArray, pC::Index2Tuple, A::AbstractArray, pA::Index2Tuple, B::AbstractArray, pB::Index2Tuple)
+    dimcheck_tensorcontract(C::AbstractArray,
+                            A::AbstractArray, pA::Index2Tuple,
+                            B::AbstractArray, pB::Index2Tuple,
+                            pAB::Index2Tuple)
 
-Check that `C`, `A` and `B` have compatible sizes for the contraction specified by `pC`, `pA` and `pB`.
+Check that `C`, `A` and `B` have compatible sizes for the contraction specified by `pA`,
+`pB` and `pAB`.
 """
-function dimcheck_tensorcontract(C::AbstractArray, pC::Index2Tuple,
+function dimcheck_tensorcontract(C::AbstractArray,
                                  A::AbstractArray, pA::Index2Tuple,
-                                 B::AbstractArray, pB::Index2Tuple)
+                                 B::AbstractArray, pB::Index2Tuple,
+                                 pAB::Index2Tuple)
     szA, szB, szC = size(A), size(B), size(C)
     TupleTools.getindices(szA, pA[2]) == TupleTools.getindices(szB, pB[1]) ||
         throw(DimensionMismatch("non-matching sizes in contracted dimensions"))
     szAB = (TupleTools.getindices(szA, pA[1])..., TupleTools.getindices(szB, pB[2])...)
-    TupleTools.getindices(szAB, linearize(pC)) == szC ||
+    TupleTools.getindices(szAB, linearize(pAB)) == szC ||
         throw(DimensionMismatch("non-matching sizes in uncontracted dimensions"))
     return nothing
 end

--- a/src/implementation/abstractarray.jl
+++ b/src/implementation/abstractarray.jl
@@ -112,7 +112,8 @@ end
 Check that `C` has compatible indices and number of dimensions with the trace of
 `A` over indices `p` and.
 """
-function argcheck_tensortrace(C::AbstractArray, A::AbstractArray, p::Index2Tuple, q::Index2Tuple)
+function argcheck_tensortrace(C::AbstractArray, A::AbstractArray, p::Index2Tuple,
+                              q::Index2Tuple)
     ndims(C) == numind(p) ||
         throw(IndexError("invalid selection of length $(ndims(C)): $p"))
     2 * numin(q) == 2 * numout(q) == ndims(A) - ndims(C) ||

--- a/src/implementation/abstractarray.jl
+++ b/src/implementation/abstractarray.jl
@@ -15,26 +15,27 @@ end
 const StridedNative = Backend{:StridedNative}
 const StridedBLAS = Backend{:StridedBLAS}
 
-function tensoradd!(C::AbstractArray, pC::Index2Tuple,
-                    A::AbstractArray, conjA::Symbol,
+function tensoradd!(C::AbstractArray,
+                    A::AbstractArray, pA::Index2Tuple, conjA::Symbol,
                     α::Number, β::Number)
-    return tensoradd!(C, pC, A, conjA, α, β, StridedNative())
+    return tensoradd!(C, A, pA, conjA, α, β, StridedNative())
 end
 
-function tensortrace!(C::AbstractArray, pC::Index2Tuple,
-                      A::AbstractArray, pA::Index2Tuple, conjA::Symbol,
-                      α, β)
-    return tensortrace!(C, pC, A, pA, conjA, α, β, StridedNative())
+function tensortrace!(C::AbstractArray,
+                      A::AbstractArray, p::Index2Tuple, q::Index2Tuple, conjA::Symbol,
+                      α::Number, β::Number)
+    return tensortrace!(C, A, p, q, conjA, α, β, StridedNative())
 end
 
-function tensorcontract!(C::AbstractArray, pC::Index2Tuple,
+function tensorcontract!(C::AbstractArray,
                          A::AbstractArray, pA::Index2Tuple, conjA::Symbol,
                          B::AbstractArray, pB::Index2Tuple, conjB::Symbol,
+                         pAB::Index2Tuple,
                          α::Number, β::Number)
     if eltype(C) <: LinearAlgebra.BlasFloat && !isa(B, Diagonal) && !isa(A, Diagonal)
-        return tensorcontract!(C, pC, A, pA, conjA, B, pB, conjB, α, β, StridedBLAS())
+        return tensorcontract!(C, A, pA, conjA, B, pB, conjB, pAB, α, β, StridedBLAS())
     else
-        return tensorcontract!(C, pC, A, pA, conjA, B, pB, conjB, α, β, StridedNative())
+        return tensorcontract!(C, A, pA, conjA, B, pB, conjB, pAB, α, β, StridedNative())
     end
 end
 
@@ -42,35 +43,41 @@ end
 # Implementation based on StridedViews
 #-------------------------------------------------------------------------------------------
 
-function tensoradd!(C::AbstractArray, pC::Index2Tuple,
-                    A::AbstractArray, conjA::Symbol,
+function tensoradd!(C::AbstractArray,
+                    A::AbstractArray, pA::Index2Tuple, conjA::Symbol,
                     α::Number, β::Number, backend::Union{StridedNative,StridedBLAS})
-    tensoradd!(StridedView(C), pC, StridedView(A), conjA, α, β, backend)
+    tensoradd!(StridedView(C), StridedView(A), pA, conjA, α, β, backend)
     return C
 end
 
-function tensortrace!(C::AbstractArray, pC::Index2Tuple,
-                      A::AbstractArray, pA::Index2Tuple, conjA::Symbol,
+function tensortrace!(C::AbstractArray,
+                      A::AbstractArray, p::Index2Tuple, q::Index2Tuple, conjA::Symbol,
                       α::Number, β::Number, backend::Union{StridedNative,StridedBLAS})
-    tensortrace!(StridedView(C), pC, StridedView(A), pA, conjA, α, β, backend)
+    tensortrace!(StridedView(C), StridedView(A), p, q, conjA, α, β, backend)
     return C
 end
 
-function tensorcontract!(C::AbstractArray, pC::Index2Tuple,
+function tensorcontract!(C::AbstractArray,
                          A::AbstractArray, pA::Index2Tuple, conjA::Symbol,
                          B::AbstractArray, pB::Index2Tuple, conjB::Symbol,
+                         pAB::Index2Tuple,
                          α::Number, β::Number, ::StridedBLAS)
-    tensorcontract!(StridedView(C), pC, StridedView(A), pA, conjA,
-                    StridedView(B), pB, conjB, α, β, StridedBLAS())
+    tensorcontract!(StridedView(C),
+                    StridedView(A), pA, conjA,
+                    StridedView(B), pB, conjB,
+                    pAB, α, β, StridedBLAS())
     return C
 end
 
-function tensorcontract!(C::AbstractArray, pC::Index2Tuple,
+function tensorcontract!(C::AbstractArray,
                          A::AbstractArray, pA::Index2Tuple, conjA::Symbol,
                          B::AbstractArray, pB::Index2Tuple, conjB::Symbol,
+                         pAB::Index2Tuple,
                          α::Number, β::Number, ::StridedNative)
-    tensorcontract!(StridedView(C), pC, StridedView(A), pA, conjA,
-                    StridedView(B), pB, conjB, α, β, StridedNative())
+    tensorcontract!(StridedView(C),
+                    StridedView(A), pA, conjA,
+                    StridedView(B), pB, conjB,
+                    pAB, α, β, StridedNative())
     return C
 end
 

--- a/src/implementation/abstractarray.jl
+++ b/src/implementation/abstractarray.jl
@@ -109,8 +109,8 @@ end
 """
     argcheck_tensortrace(C::AbstractArray, A::AbstractArray, p::Index2Tuple, q::Index2Tuple)
 
-Check that `C` has compatible indices and number of dimensions with the trace of
-`A` over indices `p` and.
+Check that the partial trace of `A` over indices `q` and with permutation of the remaining
+indices `p` is compatible with output `C`.
 """
 function argcheck_tensortrace(C::AbstractArray, A::AbstractArray, p::Index2Tuple,
                               q::Index2Tuple)

--- a/src/implementation/allocator.jl
+++ b/src/implementation/allocator.jl
@@ -30,7 +30,8 @@ used to implement different allocation strategies.
 
 See also [`tensoralloc`](@ref) and [`tensorfree!`](@ref).
 """
-function tensoralloc_add(TC, A, pA, conjA, istemp=false, backend::Backend...)
+function tensoralloc_add(TC, A, pA::Index2Tuple, conjA::Symbol, istemp::Bool=false,
+                         backend::Backend...)
     ttype = tensoradd_type(TC, A, pA, conjA)
     structure = tensoradd_structure(A, pA, conjA)
     return tensoralloc(ttype, structure, istemp, backend...)::ttype
@@ -49,8 +50,10 @@ used to implement different allocation strategies.
 
 See also [`tensoralloc`](@ref) and [`tensorfree!`](@ref).
 """
-function tensoralloc_contract(TC, A, pA, conjA, B, pB, conjB, pAB,
-                              istemp=false, backend::Backend...)
+function tensoralloc_contract(TC,
+                              A, pA::Index2Tuple, conjA::Symbol,
+                              B, pB::Index2Tuple, conjB::Symbol,
+                              pAB::Index2Tuple, istemp::Bool=false, backend::Backend...)
     ttype = tensorcontract_type(TC, A, pA, conjA, B, pB, conjB, pAB)
     structure = tensorcontract_structure(A, pA, conjA, B, pB, conjB, pAB)
     return tensoralloc(ttype, structure, istemp, backend...)::ttype

--- a/src/implementation/diagonal.jl
+++ b/src/implementation/diagonal.jl
@@ -16,7 +16,7 @@ function tensorcontract!(C::AbstractArray,
     return C
 end
 
-function tensorcontract!(C::AbstractArray, 
+function tensorcontract!(C::AbstractArray,
                          A::Diagonal, pA::Index2Tuple, conjA::Symbol,
                          B::AbstractArray, pB::Index2Tuple, conjB::Symbol,
                          pAB::Index2Tuple,
@@ -31,7 +31,7 @@ function tensorcontract!(C::AbstractArray,
     end
     tpAB = trivialpermutation(pAB)
     rpAB = (TupleTools.getindices(indCinoBA, tpAB[1]),
-           TupleTools.getindices(indCinoBA, tpAB[2]))
+            TupleTools.getindices(indCinoBA, tpAB[2]))
 
     _diagtensorcontract!(StridedView(C),
                          StridedView(B), rpB, conjB,

--- a/src/implementation/functions.jl
+++ b/src/implementation/functions.jl
@@ -141,10 +141,6 @@ See also [`tensortrace!`](@ref).
 """
 function tensortrace end
 
-function tensortrace(IC::Tuple, A, IA::Tuple, conjA::Symbol=:N, α::Number=One())
-    pC, cindA1, cindA2 = trace_indices(IA, IC)
-    return tensortrace(A, pC, (cindA1, cindA2), conjA, α)
-end
 # default `IC`
 function tensortrace(A, IA, conjA::Symbol, α::Number=One())
     return tensortrace(unique2(tuple(IA...)), A, tuple(IA...), conjA, α)
@@ -157,9 +153,10 @@ end
 function tensortrace(A, IA, α::Number=One())
     return tensortrace(unique2(tuple(IA...)), A, tuple(IA...), :N, α)
 end
-# iterables
+# labels to indices
 function tensortrace(IC, A, IA, conjA::Symbol, α::Number=One())
-    return tensortrace(tuple(IC...), A, tuple(IA...), conjA, α)
+    p, q = trace_indices(tuple(IA...), tuple(IC...))
+    return tensortrace(A, p, q, conjA, α)
 end
 # expert mode
 function tensortrace(A, p::Index2Tuple, q::Index2Tuple, conjA::Symbol, α::Number=One(),

--- a/src/implementation/functions.jl
+++ b/src/implementation/functions.jl
@@ -8,7 +8,7 @@
 
 """
     tensorcopy([IC=IA], A, IA, [conjA=:N, [α=1]])
-    tensorcopy(pC::Index2Tuple, A, conjA, α) # expert mode
+    tensorcopy(A, pA::Index2Tuple, conjA, α) # expert mode
 
 Create a copy of `A`, where the dimensions of `A` are assigned indices from the
 iterable `IA` and the indices of the copy are contained in `IC`. Both iterables
@@ -26,8 +26,8 @@ See also [`tensorcopy!`](@ref).
 function tensorcopy end
 
 function tensorcopy(IC::Tuple, A, IA::Tuple, conjA::Symbol=:N, α::Number=One())
-    pC = add_indices(IA, IC)
-    return tensorcopy(pC, A, conjA, α)
+    pA = add_indices(IA, IC)
+    return tensorcopy(A, pA, conjA, α)
 end
 # default `IC`
 function tensorcopy(A, IA, conjA::Symbol=:N, α::Number=One())
@@ -38,20 +38,20 @@ function tensorcopy(IC, A, IA, conjA::Symbol=:N, α::Number=One())
     return tensorcopy(tuple(IC...), A, tuple(IA...), conjA, α)
 end
 # expert mode
-function tensorcopy(pC::Index2Tuple, A, conjA::Symbol=:N, α::Number=One(),
+function tensorcopy(A, pA::Index2Tuple, conjA::Symbol=:N, α::Number=One(),
                     backend::Backend...)
     TC = promote_add(scalartype(A), scalartype(α))
-    C = tensoralloc_add(TC, pC, A, conjA)
-    return tensorcopy!(C, pC, A, conjA, α, backend...)
+    C = tensoralloc_add(TC, A, pA, conjA)
+    return tensorcopy!(C, A, pA, conjA, α, backend...)
 end
 
 """
-    tensorcopy!(C, pC::Index2Tuple, A, conjA=:N, α=1, [backend])
+    tensorcopy!(C, A, pA::Index2Tuple, conjA=:N, α=1, [backend])
 
 Copy the contents of tensor `A` into `C`, where the dimensions `A` are permuted according to
-the permutation and repartition `pC`.
+the permutation and repartition `pA`.
 
-The result of this method is equivalent to `α * permutedims!(C, A, pC)`.
+The result of this method is equivalent to `α * permutedims!(C, A, pA)`.
 
 Optionally, the symbol `conjA` can be used to specify whether the input tensor should be
 conjugated (`:C`) or not (`:N`).
@@ -61,9 +61,9 @@ conjugated (`:C`) or not (`:N`).
 
 See also [`tensorcopy`](@ref) and [`tensoradd!`](@ref)
 """
-function tensorcopy!(C, pC::Index2Tuple, A, conjA::Symbol=:N, α::Number=One(),
+function tensorcopy!(C, A, pA::Index2Tuple, conjA::Symbol=:N, α::Number=One(),
                      backend::Backend...)
-    return tensoradd!(C, pC, A, conjA, α, false, backend...)
+    return tensoradd!(C, A, pA, conjA, α, false, backend...)
 end
 
 # ------------------------------------------------------------------------------------------
@@ -115,9 +115,9 @@ function tensoradd(A, pA::Index2Tuple, conjA::Symbol,
                    B, pB::Index2Tuple, conjB::Symbol,
                    α::Number=One(), β::Number=One(), backend::Backend...)
     TC = promote_add(scalartype(A), scalartype(B), scalartype(α), scalartype(β))
-    C = tensoralloc_add(TC, pA, A, conjA)
-    C = tensorcopy!(C, pA, A, conjA, α)
-    return tensoradd!(C, pB, B, conjB, β, One(), backend...)
+    C = tensoralloc_add(TC, A, pA, conjA)
+    C = tensorcopy!(C, A, pA, conjA, α)
+    return tensoradd!(C, B, pB, conjB, β, One(), backend...)
 end
 
 # ------------------------------------------------------------------------------------------
@@ -126,7 +126,7 @@ end
 
 """
     tensortrace([IC], A, IA, [conjA], [α=1])
-    tensortrace(pC::Index2Tuple, A, pA::Index2Tuple, conjA, α=1, [backend]) # expert mode
+    tensortrace(A, p::Index2Tuple, q::Index2Tuple, conjA, α=1, [backend]) # expert mode
 
 Trace or contract pairs of indices of tensor `A`, by assigning them identical indices in the
 iterable `IA`. The untraced indices, which are assigned a unique index, can be reordered
@@ -143,7 +143,7 @@ function tensortrace end
 
 function tensortrace(IC::Tuple, A, IA::Tuple, conjA::Symbol=:N, α::Number=One())
     pC, cindA1, cindA2 = trace_indices(IA, IC)
-    return tensortrace(pC, A, (cindA1, cindA2), conjA, α)
+    return tensortrace(A, pC, (cindA1, cindA2), conjA, α)
 end
 # default `IC`
 function tensortrace(A, IA, conjA::Symbol, α::Number=One())
@@ -162,11 +162,11 @@ function tensortrace(IC, A, IA, conjA::Symbol, α::Number=One())
     return tensortrace(tuple(IC...), A, tuple(IA...), conjA, α)
 end
 # expert mode
-function tensortrace(pC::Index2Tuple, A, pA::Index2Tuple, conjA::Symbol, α::Number=One(),
+function tensortrace(A, p::Index2Tuple, q::Index2Tuple, conjA::Symbol, α::Number=One(),
                      backend::Backend...)
     TC = promote_contract(scalartype(A), scalartype(α))
-    C = tensoralloc_add(TC, pC, A, conjA)
-    return tensortrace!(C, pC, A, pA, conjA, α, Zero())
+    C = tensoralloc_add(TC, A, p, conjA)
+    return tensortrace!(C, A, p, q, conjA, α, Zero(), backend...)
 end
 
 # ------------------------------------------------------------------------------------------
@@ -175,7 +175,7 @@ end
 
 """
     tensorcontract([IC], A, IA, [conjA], B, IB, [conjB], [α=1])
-    tensorcontract(pC::Index2Tuple, A, pA::Index2Tuple, conjA, B, pB::Index2Tuple, conjB, α=1, [backend]) # expert mode
+    tensorcontract(A, pA::Index2Tuple, conjA, B, pB::Index2Tuple, conjB, pAB::Index2Tuple, α=1, [backend]) # expert mode
 
 Contract indices of tensor `A` with corresponding indices in tensor `B` by assigning
 them identical labels in the iterables `IA` and `IB`. The indices of the resulting
@@ -195,8 +195,8 @@ function tensorcontract end
 
 function tensorcontract(IC::Tuple, A, IA::Tuple, conjA::Symbol, B, IB::Tuple, conjB::Symbol,
                         α::Number=One())
-    pA, pB, pC = contract_indices(IA, IB, IC)
-    return tensorcontract(pC, A, pA, conjA, B, pB, conjB, α)
+    pA, pB, pAB = contract_indices(IA, IB, IC)
+    return tensorcontract(A, pA, conjA, B, pB, conjB, pAB, α)
 end
 # default `IC`
 function tensorcontract(A, IA, conjA, B, IB, conjB, α::Number=One())
@@ -217,12 +217,12 @@ function tensorcontract(IC, A, IA, conjA::Symbol, B, IB, conjB::Symbol, α::Numb
     return tensorcontract(tuple(IC...), A, tuple(IA...), conjA, B, tuple(IB...), conjB, α)
 end
 # expert mode
-function tensorcontract(pC::Index2Tuple, A, pA::Index2Tuple, conjA::Symbol, B,
-                        pB::Index2Tuple, conjB::Symbol, α::Number=One(),
-                        backend::Backend...)
+function tensorcontract(A, pA::Index2Tuple, conjA::Symbol,
+                        B, pB::Index2Tuple, conjB::Symbol,
+                        pAB::Index2Tuple, α::Number=One(), backend::Backend...)
     TC = promote_contract(scalartype(A), scalartype(B), scalartype(α))
-    C = tensoralloc_contract(TC, pC, A, pA, conjA, B, pB, conjB)
-    return tensorcontract!(C, pC, A, pA, conjA, B, pB, conjB, α, Zero(), backend...)
+    C = tensoralloc_contract(TC, A, pA, conjA, B, pB, conjB, pAB)
+    return tensorcontract!(C, A, pA, conjA, B, pB, conjB, pAB, α, Zero(), backend...)
 end
 
 # ------------------------------------------------------------------------------------------
@@ -231,7 +231,7 @@ end
 
 """
     tensorproduct([IC], A, IA, [conjA], B, IB, [conjB], [α=1])
-    tensorproduct(pC::Index2Tuple, A, pA::Index2Tuple, conjA, B, pB::Index2Tuple, conjB, α=1, [backend]) # expert mode
+    tensorproduct(A, pA::Index2Tuple, conjA, B, pB::Index2Tuple, conjB, pAB::Index2Tuple, α=1, [backend]) # expert mode
 
 Compute the tensor product (outer product) of two tensors `A` and `B`, i.e. returns a new
 tensor `C` with `ndims(C) = ndims(A) + ndims(B)`. The indices of the output tensor are
@@ -249,8 +249,8 @@ function tensorproduct end
 
 function tensorproduct(IC::Tuple, A, IA::Tuple, conjA::Symbol, B, IB::Tuple, conjB::Symbol,
                        α::Number=One())
-    pA, pB, pC = contract_indices(IA, IB, IC)
-    return tensorproduct(pC, A, pA, conjA, B, pB, conjB, α)
+    pA, pB, pAB = contract_indices(IA, IB, IC)
+    return tensorproduct(A, pA, conjA, B, pB, conjB, pAB, α)
 end
 # default `IC`
 function tensorproduct(A, IA, conjA::Symbol, B, IB, conjB::Symbol, α::Number=One())
@@ -271,15 +271,16 @@ function tensorproduct(IC, A, IA, conjA::Symbol, B, IB, conjB::Symbol, α::Numbe
     return tensorproduct(tuple(IC...), A, tuple(IA...), conjA, B, tuple(IB...), conjB, α)
 end
 # expert mode
-function tensorproduct(pC::Index2Tuple, A, pA::Index2Tuple, conjA::Symbol, B,
-                       pB::Index2Tuple, conjB::Symbol, α::Number=One(), backend::Backend...)
+function tensorproduct(A, pA::Index2Tuple, conjA::Symbol,
+                       B, pB::Index2Tuple, conjB::Symbol,
+                       pAB::Index2Tuple, α::Number=One(), backend::Backend...)
     numin(pA) == 0 && numout(pB) == 0 ||
         throw(IndexError("not a valid tensor product"))
-    return tensorcontract(pC, A, pA, conjA, B, pB, conjB, α, backend...)
+    return tensorcontract(A, pA, conjA, B, pB, conjB, pAB, α, backend...)
 end
 
 """
-    tensorproduct!(C, pC::Index2Tuple, A, pA::Index2Tuple, conjA, B, pB::Index2Tuple, conjB, α=1, β=0)
+    tensorproduct!(C, A, pA::Index2Tuple, conjA, B, pB::Index2Tuple, conjB, pAB::Index2Tuple, α=1, β=0)
 
 Compute the tensor product (outer product) of two tensors `A` and `B`, i.e. a wrapper of
 [`tensorcontract!`](@ref) with no indices being contracted over. This method checks whether
@@ -290,11 +291,12 @@ the indices indeed specify a tensor product instead of a genuine contraction.
 
 See als [`tensorproduct`](@ref) and [`tensorcontract!`](@ref).
 """
-function tensorproduct!(C, pC::Index2Tuple,
+function tensorproduct!(C,
                         A, pA::Index2Tuple, conjA::Symbol,
                         B, pB::Index2Tuple, conjB::Symbol,
+                        pAB::Index2Tuple,
                         α::Number=One(), β::Number=Zero(), backend::Backend...)
     numin(pA) == 0 && numout(pB) == 0 ||
         throw(IndexError("not a valid tensor product"))
-    return tensorcontract!(C, pC, A, pA, conjA, B, pB, conjB, α, β, backend...)
+    return tensorcontract!(C, A, pA, conjA, B, pB, conjB, pAB, α, β, backend...)
 end

--- a/src/implementation/functions.jl
+++ b/src/implementation/functions.jl
@@ -14,8 +14,8 @@ Create a copy of `A`, where the dimensions of `A` are assigned indices from the
 iterable `IA` and the indices of the copy are contained in `IC`. Both iterables
 should contain the same elements, optionally in a different order.
 
-The result of this method is equivalent to `α * permutedims(A, pC)` where `pC` is the
-permutation such that `IC = IA[pC]`. The implementation of `tensorcopy` is however more
+The result of this method is equivalent to `α * permutedims(A, pA)` where `pA` is the
+permutation such that `IC = IA[pA]`. The implementation of `tensorcopy` is however more
 efficient on average, especially if `Threads.nthreads() > 1`.
 
 Optionally, the symbol `conjA` can be used to specify whether the input tensor should be

--- a/src/implementation/indices.jl
+++ b/src/implementation/indices.jl
@@ -76,7 +76,7 @@ function trace_indices(IA::NTuple{NA,Any}, IC::NTuple{NC,Any}) where {NA,NC}
     pA = (indCinA..., cindA1..., cindA2...)
     (isperm(pA) && length(pA) == NA) ||
         throw(IndexError("invalid trace specification: $IA to $IC"))
-    return (indCinA, ()), cindA1, cindA2
+    return (indCinA, ()), (cindA1, cindA2)
 end
 
 function contract_indices(IA::NTuple{NA,Any}, IB::NTuple{NB,Any},

--- a/src/implementation/strided.jl
+++ b/src/implementation/strided.jl
@@ -1,37 +1,37 @@
 #-------------------------------------------------------------------------------------------
 # StridedView implementation
 #-------------------------------------------------------------------------------------------
-function tensoradd!(C::StridedView, pC::Index2Tuple,
-                    A::StridedView, conjA::Symbol,
+function tensoradd!(C::StridedView,
+                    A::StridedView, pA::Index2Tuple, conjA::Symbol,
                     α::Number, β::Number,
                     backend::Union{StridedNative,StridedBLAS}=StridedNative())
-    argcheck_tensoradd(C, pC, A)
-    dimcheck_tensoradd(C, pC, A)
-    if !istrivialpermutation(pC) && Base.mightalias(C, A)
+    argcheck_tensoradd(C, A, pA)
+    dimcheck_tensoradd(C, A, pA)
+    if !istrivialpermutation(pA) && Base.mightalias(C, A)
         throw(ArgumentError("output tensor must not be aliased with input tensor"))
     end
 
-    A′ = permutedims(flag2op(conjA)(A), linearize(pC))
+    A′ = permutedims(flag2op(conjA)(A), linearize(pA))
     op1 = Base.Fix2(scale, α)
     op2 = Base.Fix2(scale, β)
     Strided._mapreducedim!(op1, +, op2, size(C), (C, A′))
     return C
 end
 
-function tensortrace!(C::StridedView, pC::Index2Tuple,
-                      A::StridedView, pA::Index2Tuple, conjA::Symbol,
+function tensortrace!(C::StridedView,
+                      A::StridedView, p::Index2Tuple, q::Index2Tuple, conjA::Symbol,
                       α::Number, β::Number,
                       backend::Union{StridedNative,StridedBLAS}=StridedNative())
-    argcheck_tensortrace(C, pC, A, pA)
-    dimcheck_tensortrace(C, pC, A, pA)
+    argcheck_tensortrace(C, A, p, q)
+    dimcheck_tensortrace(C, A, p, q)
 
     Base.mightalias(C, A) &&
         throw(ArgumentError("output tensor must not be aliased with input tensor"))
 
     sizeA = i -> size(A, i)
     strideA = i -> stride(A, i)
-    tracesize = sizeA.(pA[1])
-    newstrides = (strideA.(linearize(pC))..., (strideA.(pA[1]) .+ strideA.(pA[2]))...)
+    tracesize = sizeA.(q[1])
+    newstrides = (strideA.(linearize(p))..., (strideA.(q[1]) .+ strideA.(q[2]))...)
     newsize = (size(C)..., tracesize...)
 
     A′ = flag2op(conjA)(StridedView(A.parent, newsize, newstrides, A.offset, A.op))
@@ -41,13 +41,14 @@ function tensortrace!(C::StridedView, pC::Index2Tuple,
     return C
 end
 
-function tensorcontract!(C::StridedView{T}, pC::Index2Tuple,
+function tensorcontract!(C::StridedView{T},
                          A::StridedView, pA::Index2Tuple, conjA::Symbol,
                          B::StridedView, pB::Index2Tuple, conjB::Symbol,
+                         pAB::Index2Tuple,
                          α::Number, β::Number,
                          backend::StridedBLAS=StridedBLAS()) where {T<:LinearAlgebra.BlasFloat}
-    argcheck_tensorcontract(C, pC, A, pA, B, pB)
-    dimcheck_tensorcontract(C, pC, A, pA, B, pB)
+    argcheck_tensorcontract(C, A, pA, B, pB, pAB)
+    dimcheck_tensorcontract(C, A, pA, B, pB, pAB)
 
     (Base.mightalias(C, A) || Base.mightalias(C, B)) &&
         throw(ArgumentError("output tensor must not be aliased with input tensor"))
@@ -55,27 +56,27 @@ function tensorcontract!(C::StridedView{T}, pC::Index2Tuple,
     rpA = reverse(pA)
     rpB = reverse(pB)
     indCinoBA = let N₁ = numout(pA), N₂ = numin(pB)
-        map(n -> ifelse(n > N₁, n - N₁, n + N₂), linearize(pC))
+        map(n -> ifelse(n > N₁, n - N₁, n + N₂), linearize(pAB))
     end
-    tpC = trivialpermutation(pC)
-    rpC = (TupleTools.getindices(indCinoBA, tpC[1]),
-           TupleTools.getindices(indCinoBA, tpC[2]))
-    if contract_memcost(C, pC, A, pA, conjA, B, pB, conjB) <=
-       contract_memcost(C, rpC, B, rpB, conjB, A, rpA, conjA)
-        return blas_contract!(C, pC, A, pA, conjA, B, pB, conjB, α, β)
+    tpAB = trivialpermutation(pAB)
+    rpAB = (TupleTools.getindices(indCinoBA, tpAB[1]),
+           TupleTools.getindices(indCinoBA, tpAB[2]))
+    if contract_memcost(C, A, pA, conjA, B, pB, conjB, pAB) <=
+       contract_memcost(C, B, rpB, conjB, A, rpA, conjA, rpAB)
+        return blas_contract!(C, A, pA, conjA, B, pB, conjB, pAB, α, β)
     else
-        return blas_contract!(C, rpC, B, rpB, conjB, A, rpA, conjA, α, β)
+        return blas_contract!(C, B, rpB, conjB, A, rpA, conjA, rpAB, α, β)
     end
 end
 
 # reduce overhead for the case where it is just matrix multiplication
-function tensorcontract!(C::StridedView{T,2}, pC::Index2Tuple{1,1},
+function tensorcontract!(C::StridedView{T,2},
                          A::StridedView{T,2}, pA::Index2Tuple{1,1}, conjA::Symbol,
                          B::StridedView{T,2}, pB::Index2Tuple{1,1}, conjB::Symbol,
-                         α::Number, β::Number,
+                         pAB::Index2Tuple{1,1}, α::Number, β::Number,
                          backend::StridedBLAS=StridedBLAS()) where {T<:LinearAlgebra.BlasFloat}
-    argcheck_tensorcontract(C, pC, A, pA, B, pB)
-    dimcheck_tensorcontract(C, pC, A, pA, B, pB)
+    argcheck_tensorcontract(C, A, pA, B, pB, pAB)
+    dimcheck_tensorcontract(C, A, pA, B, pB, pAB)
 
     (Base.mightalias(C, A) || Base.mightalias(C, B)) &&
         throw(ArgumentError("output tensor must not be aliased with input tensor"))
@@ -84,21 +85,21 @@ function tensorcontract!(C::StridedView{T,2}, pC::Index2Tuple{1,1},
     opB = flag2op(conjB)
     A′ = pA == ((1,), (2,)) ? opA(A) : opA(permutedims(A, (pA[1][1], pA[2][1])))
     B′ = pB == ((1,), (2,)) ? opB(B) : opB(permutedims(B, (pB[1][1], pB[2][1])))
-    if pC == ((1,), (2,))
+    if pAB == ((1,), (2,))
         mul!(C, A′, B′, α, β)
-    elseif pC == ((2,), (1,))
+    elseif pAB == ((2,), (1,))
         mul!(C, transpose(B′), transpose(A′), α, β)
     end
     return C
 end
 
-function tensorcontract!(C::StridedView, pC::Index2Tuple,
+function tensorcontract!(C::StridedView,
                          A::StridedView, pA::Index2Tuple, conjA::Symbol,
                          B::StridedView, pB::Index2Tuple, conjB::Symbol,
-                         α::Number, β::Number,
+                         pAB::Index2Tuple, α::Number, β::Number,
                          backend::StridedNative)
-    argcheck_tensorcontract(C, pC, A, pA, B, pB)
-    dimcheck_tensorcontract(C, pC, A, pA, B, pB)
+    argcheck_tensorcontract(C, A, pA, B, pB, pAB)
+    dimcheck_tensorcontract(C, A, pA, B, pB, pAB)
 
     sizeA = size(A)
     sizeB = size(B)
@@ -111,7 +112,7 @@ function tensorcontract!(C::StridedView, pC::Index2Tuple,
                   (osizeA..., one.(osizeB)..., csizeA...))
     BS = sreshape(permutedims(flag2op(conjB)(B), linearize(reverse(pB))),
                   (one.(osizeA)..., osizeB..., csizeB...))
-    CS = sreshape(permutedims(C, invperm(linearize(pC))),
+    CS = sreshape(permutedims(C, invperm(linearize(pAB))),
                   (osizeA..., osizeB..., one.(csizeA)...))
     tsize = (osizeA..., osizeB..., csizeA...)
 
@@ -124,22 +125,22 @@ end
 #-------------------------------------------------------------------------------------------
 # StridedViewBLAS contraction implementation
 #-------------------------------------------------------------------------------------------
-function blas_contract!(C, pC, A, pA, conjA, B, pB, conjB, α, β)
+function blas_contract!(C, A, pA, conjA, B, pB, conjB, pAB, α, β)
     TC = eltype(C)
 
     A_, pA, conjA, flagA = makeblascontractable(A, pA, conjA, TC)
     B_, pB, conjB, flagB = makeblascontractable(B, pB, conjB, TC)
 
-    ipC = oindABinC(pC, pA, pB)
-    flagC = isblascontractable(C, ipC, :D)
+    ipAB = oindABinC(pAB, pA, pB)
+    flagC = isblascontractable(C, ipAB, :D)
     if flagC
         C_ = C
-        _unsafe_blas_contract!(C_, ipC, A_, pA, conjA, B_, pB, conjB, α, β)
+        _unsafe_blas_contract!(C_, A_, pA, conjA, B_, pB, conjB, ipAB, α, β)
     else
-        C_ = StridedView(TensorOperations.tensoralloc_add(TC, ipC, C, :N, true))
-        ipC = trivialpermutation(ipC)
-        _unsafe_blas_contract!(C_, ipC, A_, pA, conjA, B_, pB, conjB, one(TC), zero(TC))
-        tensoradd!(C, pC, C_, :N, α, β)
+        C_ = StridedView(TensorOperations.tensoralloc_add(TC, C, ipAB, :N, true))
+        _unsafe_blas_contract!(C_, A_, pA, conjA, B_, pB, conjB, trivialpermutation(ipAB),
+                               one(TC), zero(TC))
+        tensoradd!(C, C_, pAB, :N, α, β)
         tensorfree!(C_.parent)
     end
     flagA || tensorfree!(A_.parent)
@@ -147,9 +148,10 @@ function blas_contract!(C, pC, A, pA, conjA, B, pB, conjB, α, β)
     return C
 end
 
-function _unsafe_blas_contract!(C::StridedView{T}, ipC,
+function _unsafe_blas_contract!(C::StridedView{T},
                                 A::StridedView{T}, pA, conjA,
-                                B::StridedView{T}, pB, conjB, α, β) where {T<:BlasFloat}
+                                B::StridedView{T}, pB, conjB,
+                                pAB, α, β) where {T<:BlasFloat}
     sizeA = size(A)
     sizeB = size(B)
     csizeA = TupleTools.getindices(sizeA, pA[2])
@@ -160,7 +162,7 @@ function _unsafe_blas_contract!(C::StridedView{T}, ipC,
     opA = flag2op(conjA)
     opB = flag2op(conjB)
 
-    mul!(sreshape(permutedims(C, linearize(ipC)), (prod(osizeA), prod(osizeB))),
+    mul!(sreshape(permutedims(C, linearize(pAB)), (prod(osizeA), prod(osizeB))),
          opA(sreshape(permutedims(A, linearize(pA)), (prod(osizeA), prod(csizeA)))),
          opB(sreshape(permutedims(B, linearize(pB)), (prod(csizeB), prod(osizeB)))),
          α, β)
@@ -171,8 +173,8 @@ end
 @inline function makeblascontractable(A, pA, conjA, TC)
     flagA = isblascontractable(A, pA, conjA) && eltype(A) == TC
     if !flagA
-        A_ = StridedView(TensorOperations.tensoralloc_add(TC, pA, A, conjA, true))
-        A = tensoradd!(A_, pA, A, conjA, One(), Zero())
+        A_ = StridedView(TensorOperations.tensoralloc_add(TC, A, pA, conjA, true))
+        A = tensoradd!(A_, A, pA, conjA, One(), Zero())
         conjA = :N
         pA = trivialpermutation(pA)
     end
@@ -218,18 +220,18 @@ _canfuse(dims::Dims{1}, strides::Dims{1}) = true, dims[1], strides[1]
     end
 end
 
-function oindABinC(pC, pA, pB)
-    ipC = invperm(linearize(pC))
-    oindAinC = TupleTools.getindices(ipC, trivialpermutation(pA[1]))
-    oindBinC = TupleTools.getindices(ipC, numout(pA) .+ trivialpermutation(pB[2]))
+function oindABinC(pAB, pA, pB)
+    ipAB = invperm(linearize(pAB))
+    oindAinC = TupleTools.getindices(ipAB, trivialpermutation(pA[1]))
+    oindBinC = TupleTools.getindices(ipAB, numout(pA) .+ trivialpermutation(pB[2]))
     return (oindAinC, oindBinC)
 end
 
-function contract_memcost(C, pC, A, pA, conjA, B, pB, conjB)
-    ipC = oindABinC(pC, pA, pB)
+function contract_memcost(C, A, pA, conjA, B, pB, conjB, pAB)
+    ipAB = oindABinC(pAB, pA, pB)
     return length(A) *
            (!isblascontractable(A, pA, conjA) || eltype(A) !== eltype(C)) +
            length(B) *
            (!isblascontractable(B, pB, conjB) || eltype(B) !== eltype(C)) +
-           length(C) * !isblascontractable(C, ipC, :D)
+           length(C) * !isblascontractable(C, ipAB, :D)
 end

--- a/src/implementation/strided.jl
+++ b/src/implementation/strided.jl
@@ -60,7 +60,7 @@ function tensorcontract!(C::StridedView{T},
     end
     tpAB = trivialpermutation(pAB)
     rpAB = (TupleTools.getindices(indCinoBA, tpAB[1]),
-           TupleTools.getindices(indCinoBA, tpAB[2]))
+            TupleTools.getindices(indCinoBA, tpAB[2]))
     if contract_memcost(C, A, pA, conjA, B, pB, conjB, pAB) <=
        contract_memcost(C, B, rpB, conjB, A, rpA, conjA, rpAB)
         return blas_contract!(C, A, pA, conjA, B, pB, conjB, pAB, α, β)

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -3,9 +3,9 @@
 #-------------------------------------------------------------------------------------------
 
 """
-    tensoradd!(C, pC, A, conjA, α=1, β=1 [, backend])
+    tensoradd!(C, A, pA, conjA, α=1, β=1 [, backend])
 
-Compute `C = β * C + α * permutedims(opA(A), pC)` without creating the intermediate
+Compute `C = β * C + α * permutedims(opA(A), pA)` without creating the intermediate
 temporary. The operation `opA` acts as `identity` if `conjA` equals `:N` and as `conj`
 if `conjA` equals `:C`. Optionally specify a backend implementation to use.
 
@@ -16,17 +16,17 @@ See also [`tensoradd`](@ref).
 """
 function tensoradd! end
 # insert default α and β arguments
-function tensoradd!(C, pC::Index2Tuple, A, conjA::Symbol)
-    return tensoradd!(C, pC, A, conjA, One(), One())
+function tensoradd!(C, A, pA::Index2Tuple, conjA::Symbol)
+    return tensoradd!(C, A, pA, conjA, One(), One())
 end
 
 """
-    tensortrace!(C, pC, A, pA, conjA, α=1, β=0 [, backend])
+    tensortrace!(C, A, p, q, conjA, α=1, β=0 [, backend])
 
-Compute `C = β * C + α * permutedims(partialtrace(opA(A)), pC)` without creating the
-intermediate temporary, where `A` is partially traced, such that indices in `pA[1]` are
-contracted with indices in `pA[2]`, and the remaining indices are permuted according
-to `pC`. The operation `opA` acts as `identity` if `conjA` equals `:N` and as `conj` if
+Compute `C = β * C + α * permutedims(opA(A), (p, q))` without creating the
+intermediate temporary, where `A` is partially traced, such that indices in `q[1]` are
+contracted with indices in `q[2]`, and the other indices are permuted according
+to `p`. The operation `opA` acts as `identity` if `conjA` equals `:N` and as `conj` if
 `conjA` equals `:C`. Optionally specify a backend implementation to use.
 
 !!! warning
@@ -36,17 +36,17 @@ See also [`tensortrace`](@ref).
 """
 function tensortrace! end
 # insert default α and β arguments
-function tensortrace!(C, pC::Index2Tuple, A, pA::Index2Tuple, conjA::Symbol)
-    return tensortrace!(C, pC, A, pA, conjA, One(), Zero())
+function tensortrace!(C, A, p::Index2Tuple, q::Index2Tuple, conjA::Symbol)
+    return tensortrace!(C, A, p, q, conjA, One(), Zero())
 end
 
 """
-    tensorcontract!(C, pC, A, pA, conjA, B, pB, conjB, α=1, β=0 [, backend])
+    tensorcontract!(C, A, pA, conjA, B, pB, conjB, pAB, α=1, β=0 [, backend])
 
-Compute `C = β * C + α * permutedims(contract(opA(A), opB(B)), pC)` without creating the
+Compute `C = β * C + α * permutedims(contract(opA(A), opB(B)), pAB)` without creating the
 intermediate temporary, where `A` and `B` are contracted such that the indices `pA[2]` of
 `A` are contracted with indices `pB[1]` of `B`. The remaining indices `(pA[1]..., pB[2]...)`
-are then permuted according to `pC`. The operation `opA` acts as `identity` if `conjA`
+are then permuted according to `pAB`. The operation `opA` acts as `identity` if `conjA`
 equals `:N` and as `conj` if `conjA` equals `:C`; the operation `opB` is determined by
 `conjB` analogously. Optionally specify a backend implementation to use.
 
@@ -57,10 +57,11 @@ See also [`tensorcontract`](@ref).
 """
 function tensorcontract! end
 # insert default α and β arguments
-function tensorcontract!(C, pC::Index2Tuple,
+function tensorcontract!(C,
                          A, pA::Index2Tuple, conjA::Symbol,
-                         B, pB::Index2Tuple, conjB::Symbol)
-    return tensorcontract!(C, pC, A, pA, conjA, B, pB, conjB, One(), Zero())
+                         B, pB::Index2Tuple, conjB::Symbol,
+                         pAB::Index2Tuple)
+    return tensorcontract!(C, A, pA, conjA, B, pB, conjB, pAB, One(), Zero())
 end
 
 """
@@ -84,34 +85,34 @@ Obtain the information associated to indices `iA` of tensor `op(A)`, where `op` 
 function tensorstructure end
 
 """
-    tensoradd_structure(pC, A, conjA)
+    tensoradd_structure(A, pA, conjA)
 
 Obtain the structure information of `C`, where `C` would be the output of
-`tensoradd!(C, pC, A, conjA)`.
+`tensoradd!(C, A, pA, conjA)`.
 """
 function tensoradd_structure end
 
 """
-    tensorcontract_structure(pC, A, pA, conjA, B, pB, conjB)
+    tensorcontract_structure(A, pA, conjA, B, pB, conjB, pAB)
 
 Obtain the structure information of `C`, where `C` would be the output of
-`tensorcontract!(C, pC, A, pA, conjA, B, pB, conjB)`.
+`tensorcontract!(C, A, pA, conjA, B, pB, conjB, pAB)`.
 """
 function tensorcontract_structure end
 
 """
-    tensoradd_type(TC, pC, A, conjA)
+    tensoradd_type(TC, A, pA, conjA)
 
-Obtain `typeof(C)`, where `C` is the result of `tensoradd!(C, pC, A, conjA)`
-with scalar type `TC`.
+Obtain the type information of `C`, where `C` would be the output of
+`tensoradd!(C, A, pA, conjA)` with scalartype `TC`.
 """
 function tensoradd_type end
 
 """
-    tensorcontract_type(TC, pC, A, pA, conjA, B, pB, conjB)
+    tensorcontract_type(TC, A, pA, conjA, B, pB, conjB, pAB)
 
-Obtain `typeof(C)`, where `C` is the result of
-`tensorcontract!(C, pC, A, pA, conjA, B, pB, conjB)` with scalar type `TC`.
+Obtain the type information of `C`, where `C` would be the output of
+`tensorcontract!(C, A, pA, conjA, B, pB, conjB, pAB)` with scalar type `TC`.
 """
 function tensorcontract_type end
 

--- a/test/ad.jl
+++ b/test/ad.jl
@@ -14,18 +14,18 @@ precision(::Type{<:Union{Float64,Complex{Float64}}}) = 1e-8
     atol = max(precision(T₁), precision(T₂))
     rtol = max(precision(T₁), precision(T₂))
 
-    pC = ((3, 5, 2), ())
-    pA = ((1,), (4,))
+    p = ((3, 5, 2), ())
+    q = ((1,), (4,))
     α = rand(T)
     β = rand(T)
     A = rand(T₁, (2, 3, 4, 2, 5))
-    C = rand(T₂, size.(Ref(A), pC[1]))
+    C = rand(T₂, size.(Ref(A), p[1]))
 
-    test_rrule(tensortrace!, C, pC, A, pA, :N, α, β; atol, rtol)
-    test_rrule(tensortrace!, C, pC, A, pA, :C, α, β; atol, rtol)
+    test_rrule(tensortrace!, C, A, p, q, :N, α, β; atol, rtol)
+    test_rrule(tensortrace!, C, A, p, q, :C, α, β; atol, rtol)
 
-    test_rrule(tensortrace!, C, pC, A, pA, :C, α, β, StridedBLAS(); atol, rtol)
-    test_rrule(tensortrace!, C, pC, A, pA, :N, α, β, StridedNative(); atol, rtol)
+    test_rrule(tensortrace!, C, A, p, q, :C, α, β, StridedBLAS(); atol, rtol)
+    test_rrule(tensortrace!, C, A, p, q, :N, α, β, StridedNative(); atol, rtol)
 end
 
 @testset "tensoradd! ($T₁, $T₂)" for (T₁, T₂) in ((Float64, Float64), (Float32, Float64),
@@ -34,16 +34,16 @@ end
     atol = max(precision(T₁), precision(T₂))
     rtol = max(precision(T₁), precision(T₂))
 
-    pC = ((2, 1, 4, 3, 5), ())
+    pA = ((2, 1, 4, 3, 5), ())
     A = rand(T₁, (2, 3, 4, 2, 1))
-    C = rand(T₂, size.(Ref(A), pC[1]))
+    C = rand(T₂, size.(Ref(A), pA[1]))
     α = rand(T)
     β = rand(T)
-    test_rrule(tensoradd!, C, pC, A, :N, α, β; atol, rtol)
-    test_rrule(tensoradd!, C, pC, A, :C, α, β; atol, rtol)
+    test_rrule(tensoradd!, C, A, pA, :N, α, β; atol, rtol)
+    test_rrule(tensoradd!, C, A, pA, :C, α, β; atol, rtol)
 
-    test_rrule(tensoradd!, C, pC, A, :N, α, β, StridedBLAS(); atol, rtol)
-    test_rrule(tensoradd!, C, pC, A, :C, α, β, StridedNative(); atol, rtol)
+    test_rrule(tensoradd!, C, A, pA, :N, α, β, StridedBLAS(); atol, rtol)
+    test_rrule(tensoradd!, C, A, pA, :C, α, β, StridedNative(); atol, rtol)
 end
 
 @testset "tensorcontract! ($T₁, $T₂)" for (T₁, T₂) in
@@ -53,7 +53,7 @@ end
     atol = max(precision(T₁), precision(T₂))
     rtol = max(precision(T₁), precision(T₂))
 
-    pC = ((3, 2, 4, 1), ())
+    pAB = ((3, 2, 4, 1), ())
     pA = ((2, 4, 5), (1, 3))
     pB = ((2, 1), (3,))
 
@@ -63,14 +63,14 @@ end
     α = randn(T)
     β = randn(T)
 
-    test_rrule(tensorcontract!, C, pC, A, pA, :N, B, pB, :N, α, β; atol, rtol)
-    test_rrule(tensorcontract!, C, pC, A, pA, :C, B, pB, :N, α, β; atol, rtol)
-    test_rrule(tensorcontract!, C, pC, A, pA, :N, B, pB, :C, α, β; atol, rtol)
-    test_rrule(tensorcontract!, C, pC, A, pA, :C, B, pB, :C, α, β; atol, rtol)
+    test_rrule(tensorcontract!, C, A, pA, :N, B, pB, :N, pAB, α, β; atol, rtol)
+    test_rrule(tensorcontract!, C, A, pA, :C, B, pB, :N, pAB, α, β; atol, rtol)
+    test_rrule(tensorcontract!, C, A, pA, :N, B, pB, :C, pAB, α, β; atol, rtol)
+    test_rrule(tensorcontract!, C, A, pA, :C, B, pB, :C, pAB, α, β; atol, rtol)
 
-    test_rrule(tensorcontract!, C, pC, A, pA, :N, B, pB, :N, α, β, StridedBLAS();
+    test_rrule(tensorcontract!, C, A, pA, :N, B, pB, :N, pAB, α, β, StridedBLAS();
                atol, rtol)
-    test_rrule(tensorcontract!, C, pC, A, pA, :C, B, pB, :N, α, β, StridedNative();
+    test_rrule(tensorcontract!, C, A, pA, :C, B, pB, :N, pAB, α, β, StridedNative();
                atol, rtol)
 end
 

--- a/test/auxiliary.jl
+++ b/test/auxiliary.jl
@@ -225,13 +225,13 @@ end
         @test_throws IndexError trace_indices((:a, :b, :c, :d, :d), (:a, :b, :c, :d, :d))
 
         # only tests for all indices to the left, labels defaults to this
-        for (pC, iA₁, iA₂) in
-            ((((1, 2, 3), ()), (4,), (5,)), (((3, 4, 2), ()), (1,), (5,)),
-             (((3, 1, 4, 5), ()), (6, 7), (2, 8)))
-            pC′, (iA₁′, iA₂′) = trace_indices(trace_labels(pC, iA₁, iA₂)...)
-            @test pC′ == pC
-            @test issetequal([Set([i1, i2]) for (i1, i2) in zip(iA₁, iA₂)],
-                             [Set([i1, i2]) for (i1, i2) in zip(iA₁′, iA₂′)])
+        for (p, q) in
+            ((((1, 2, 3), ()), ((4,), (5,))), (((3, 4, 2), ()), ((1,), (5,))),
+             (((3, 1, 4, 5), ()), ((6, 7), (2, 8))))
+            p′, q′ = trace_indices(trace_labels(p, q)...)
+            @test p′ == p
+            @test issetequal([Set([i1, i2]) for (i1, i2) in zip(q...)],
+                             [Set([i1, i2]) for (i1, i2) in zip(q′...)])
         end
     end
 
@@ -244,11 +244,11 @@ end
         @test_throws IndexError contract_indices((:a, :b, :c), (:c, :d), (:a, :b, :d, :e))
         @test_throws IndexError contract_indices((:a, :b, :c), (:c, :d), (:a, :b, :e))
 
-        for (pA, pB, pC) in
+        for (pA, pB, pAB) in
             ((((1, 2), (3,)), ((1,), (2,)), ((1, 2, 3), ())),
              (((2, 3), (1,)), ((1,), (2,)), ((1, 2, 3), ())),
              (((1, 3), (2, 4)), ((1, 3), (2,)), ((2, 3, 1), ())))
-            @test contract_indices(contract_labels(pA, pB, pC)...) == (pA, pB, pC)
+            @test contract_indices(contract_labels(pA, pB, pAB)...) == (pA, pB, pAB)
         end
     end
 end

--- a/test/auxiliary.jl
+++ b/test/auxiliary.jl
@@ -215,11 +215,11 @@ end
 
     @testset "trace" begin
         @test trace_indices((:a, :b, :c, :d, :d), (:a, :b, :c)) ==
-              (((1, 2, 3), ()), (4,), (5,))
+              (((1, 2, 3), ()), ((4,), (5,)))
         @test trace_indices((:a, :b, :c, :d, :d), (:c, :b, :a)) ==
-              (((3, 2, 1), ()), (4,), (5,))
+              (((3, 2, 1), ()), ((4,), (5,)))
         @test trace_indices((4, :b, 3, 1, 4), (3, 1, :b)) ==
-              (((3, 4, 2), ()), (1,), (5,))
+              (((3, 4, 2), ()), ((1,), (5,)))
 
         @test_throws IndexError trace_indices((:a, :b, :c, :d, :d), (:a, :b, :d))
         @test_throws IndexError trace_indices((:a, :b, :c, :d, :d), (:a, :b, :c, :d, :d))
@@ -228,7 +228,7 @@ end
         for (pC, iA₁, iA₂) in
             ((((1, 2, 3), ()), (4,), (5,)), (((3, 4, 2), ()), (1,), (5,)),
              (((3, 1, 4, 5), ()), (6, 7), (2, 8)))
-            pC′, iA₁′, iA₂′ = trace_indices(trace_labels(pC, iA₁, iA₂)...)
+            pC′, (iA₁′, iA₂′) = trace_indices(trace_labels(pC, iA₁, iA₂)...)
             @test pC′ == pC
             @test issetequal([Set([i1, i2]) for (i1, i2) in zip(iA₁, iA₂)],
                              [Set([i1, i2]) for (i1, i2) in zip(iA₁′, iA₂′)])

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -103,12 +103,12 @@ using TensorOperations: IndexError
         Acopy = tensorcopy(A, 1:4)
         Ccopy = tensorcopy(C, 1:4)
         pC = (p, ())
-        tensorcopy!(C, pC, A, :N)
-        tensorcopy!(Ccopy, pC, Acopy, :N)
+        tensorcopy!(C, A, pC, :N)
+        tensorcopy!(Ccopy, Acopy, pC, :N)
         @test C ≈ Ccopy
-        @test_throws IndexError tensorcopy!(C, ((1, 2, 3), ()), A, :N)
-        @test_throws DimensionMismatch tensorcopy!(C, ((1, 2, 3, 4), ()), A, :N)
-        @test_throws IndexError tensorcopy!(C, ((1, 2, 2, 3), ()), A, :N)
+        @test_throws IndexError tensorcopy!(C, A, ((1, 2, 3), ()), :N)
+        @test_throws DimensionMismatch tensorcopy!(C, A, ((1, 2, 3, 4), ()), :N)
+        @test_throws IndexError tensorcopy!(C, A, ((1, 2, 2, 3), ()), :N)
     end
 
     @testset "tensoradd!" begin
@@ -121,12 +121,12 @@ using TensorOperations: IndexError
         Ccopy = tensorcopy(1:4, C, 1:4)
         α = randn(Float64)
         β = randn(Float64)
-        tensoradd!(C, (p, ()), A, :N, α, β)
+        tensoradd!(C, A, (p, ()), :N, α, β)
         Ccopy = β * Ccopy + α * Acopy
         @test C ≈ Ccopy
-        @test_throws IndexError tensoradd!(C, ((1, 2, 3), ()), A, :N, 1.2, 0.5)
-        @test_throws DimensionMismatch tensoradd!(C, ((1, 2, 3, 4), ()), A, :N, 1.2, 0.5)
-        @test_throws IndexError tensoradd!(C, ((1, 1, 2, 3), ()), A, :N, 1.2, 0.5)
+        @test_throws IndexError tensoradd!(C, A, ((1, 2, 3), ()), :N, 1.2, 0.5)
+        @test_throws DimensionMismatch tensoradd!(C, A, ((1, 2, 3, 4), ()), :N, 1.2, 0.5)
+        @test_throws IndexError tensoradd!(C, A, ((1, 1, 2, 3), ()), :N, 1.2, 0.5)
     end
 
     @testset "tensortrace!" begin
@@ -138,17 +138,17 @@ using TensorOperations: IndexError
         Bcopy = tensorcopy(B, 1:2)
         α = randn(Float64)
         β = randn(Float64)
-        tensortrace!(B, ((2, 3), ()), A, ((1,), (4,)), :N, α, β)
+        tensortrace!(B, A, ((2, 3), ()), ((1,), (4,)), :N, α, β)
         Bcopy = β * Bcopy
         for i in 1 .+ (0:8)
             Bcopy += α * view(A, i, :, :, i)
         end
         @test B ≈ Bcopy
-        @test_throws IndexError tensortrace!(B, ((1,), ()), A, ((2,), (3,)), :N, α, β)
-        @test_throws DimensionMismatch tensortrace!(B, ((1, 4), ()), A, ((2,), (3,)), :N, α,
+        @test_throws IndexError tensortrace!(B, A, ((1,), ()), ((2,), (3,)), :N, α, β)
+        @test_throws DimensionMismatch tensortrace!(B, A, ((1, 4), ()), ((2,), (3,)), :N, α,
                                                     β)
-        @test_throws IndexError tensortrace!(B, ((1, 4), ()), A, ((1, 1), (4,)), :N, α, β)
-        @test_throws DimensionMismatch tensortrace!(B, ((1, 4), ()), A, ((1,), (3,)), :N, α,
+        @test_throws IndexError tensortrace!(B, A, ((1, 4), ()), ((1, 1), (4,)), :N, α, β)
+        @test_throws DimensionMismatch tensortrace!(B, A, ((1, 4), ()), ((1,), (3,)), :N, α,
                                                     β)
     end
 
@@ -170,20 +170,24 @@ using TensorOperations: IndexError
                 Ccopy[d, a, e] += α * A[a, b, c, d] * conj(B[c, e, b])
             end
         end
-        tensorcontract!(C, ((1, 2, 3), ()), A, ((4, 1), (2, 3)), :N, B, ((3, 1), (2,)), :C,
-                        α, β)
+        tensorcontract!(C, A, ((4, 1), (2, 3)), :N, B, ((3, 1), (2,)), :C,
+                        ((1, 2, 3), ()), α, β)
         @test C ≈ Ccopy
-        @test_throws IndexError tensorcontract!(C, ((1, 2, 3), ()),
+        @test_throws IndexError tensorcontract!(C,
                                                 A, ((4, 1), (2, 4)), :N,
-                                                B, ((1, 3), (2,)), :N, α, β)
-        @test_throws IndexError tensorcontract!(C, ((1, 2, 3), ()),
+                                                B, ((1, 3), (2,)), :N,
+                                                ((1, 2, 3), ()), α, β)
+        @test_throws IndexError tensorcontract!(C,
                                                 A, ((4, 1), (2, 3)), :N,
-                                                B, ((1, 3), ()), :N, α, β)
-        @test_throws IndexError tensorcontract!(C, ((1, 2), ()),
+                                                B, ((1, 3), ()), :N,
+                                                ((1, 2, 3), ()), α, β)
+        @test_throws IndexError tensorcontract!(C,
                                                 A, ((4, 1), (2, 3)), :N,
-                                                B, ((1, 3), (2,)), :N, α, β)
-        @test_throws DimensionMismatch tensorcontract!(C, ((1, 3, 2), ()),
+                                                B, ((1, 3), (2,)), :N,
+                                                ((1, 2), ()), α, β)
+        @test_throws DimensionMismatch tensorcontract!(C,
                                                        A, ((4, 1), (2, 3)), :N,
-                                                       B, ((1, 3), (2,)), :N, α, β)
+                                                       B, ((1, 3), (2,)), :N,
+                                                       ((1, 3, 2), ()), α, β)
     end
 end


### PR DESCRIPTION
This changes the argument order of the interface functions to the following:

```julia
tensorcontract!(C, A, pA, conjA, B, pB, conjB, pAB, alfa, beta, backend) # beta * C + alfa * permutedims(permutedims(A, pA) * permutedims(B, pB), pAB)
tensoradd!(C, A, pA, conjA, alfa, beta, backend) # beta * C + alfa * permutedims(A, pA)
tensortrace!(C, A, p, q, conjA, alfa, beta, backend) # beta * C + alfa * permuteandtracedims(A, p, q)
```

```julia
tensorcopy([IC], A, IA, [conjA,] [alfa,] [backend])
tensoradd([IC], A, IA, [conjA,] B, IB, [conjB,] [alfa, beta,] [backend])
tensortrace([IC], A, IA, [conjA], [alfa], [backend])
tensorcontract([IC], A, IA, [conjA], B, IB, [conjB], [alfa,] [backend])
tensorproduct([IC], A, IA, [conjA], B, IB, [conjB], [alfa,] [backend])
```

with the exclusion of the cutensor extension, due to the imminent changes from cuTensor v2