### PR TITLE
Change `conj` flags from `Symbol` to `Bool`

### DIFF
--- a/src/implementation/allocator.jl
+++ b/src/implementation/allocator.jl
@@ -30,7 +30,7 @@ used to implement different allocation strategies.
 
 See also [`tensoralloc`](@ref) and [`tensorfree!`](@ref).
 """
-function tensoralloc_add(TC, A, pA::Index2Tuple, conjA::Symbol, istemp::Bool=false,
+function tensoralloc_add(TC, A, pA::Index2Tuple, conjA::Bool, istemp::Bool=false,
                          backend::Backend...)
     ttype = tensoradd_type(TC, A, pA, conjA)
     structure = tensoradd_structure(A, pA, conjA)
@@ -51,8 +51,8 @@ used to implement different allocation strategies.
 See also [`tensoralloc`](@ref) and [`tensorfree!`](@ref).
 """
 function tensoralloc_contract(TC,
-                              A, pA::Index2Tuple, conjA::Symbol,
-                              B, pB::Index2Tuple, conjB::Symbol,
+                              A, pA::Index2Tuple, conjA::Bool,
+                              B, pB::Index2Tuple, conjB::Bool,
                               pAB::Index2Tuple, istemp::Bool=false, backend::Backend...)
     ttype = tensorcontract_type(TC, A, pA, conjA, B, pB, conjB, pAB)
     structure = tensorcontract_structure(A, pA, conjA, B, pB, conjB, pAB)
@@ -64,13 +64,13 @@ end
 # ------------------------------------------------------------------------------------------
 
 tensorstructure(A::AbstractArray) = size(A)
-tensorstructure(A::AbstractArray, iA::Int, conjA::Symbol) = size(A, iA)
+tensorstructure(A::AbstractArray, iA::Int, conjA::Bool) = size(A, iA)
 
-function tensoradd_type(TC, A::AbstractArray, pA::Index2Tuple, conjA::Symbol)
+function tensoradd_type(TC, A::AbstractArray, pA::Index2Tuple, conjA::Bool)
     return Array{TC,sum(length.(pA))}
 end
 
-function tensoradd_structure(A::AbstractArray, pA::Index2Tuple, conjA::Symbol)
+function tensoradd_structure(A::AbstractArray, pA::Index2Tuple, conjA::Bool)
     return size.(Ref(A), linearize(pA))
 end
 

--- a/src/implementation/diagonal.jl
+++ b/src/implementation/diagonal.jl
@@ -2,8 +2,8 @@
 # Specialized implementations for contractions involving diagonal matrices
 #-------------------------------------------------------------------------------------------
 function tensorcontract!(C::AbstractArray,
-                         A::AbstractArray, pA::Index2Tuple, conjA::Symbol,
-                         B::Diagonal, pB::Index2Tuple, conjB::Symbol,
+                         A::AbstractArray, pA::Index2Tuple, conjA::Bool,
+                         B::Diagonal, pB::Index2Tuple, conjB::Bool,
                          pAB::Index2Tuple,
                          α::Number, β::Number, ::StridedNative)
     argcheck_tensorcontract(C, A, pA, B, pB, pAB)
@@ -17,8 +17,8 @@ function tensorcontract!(C::AbstractArray,
 end
 
 function tensorcontract!(C::AbstractArray,
-                         A::Diagonal, pA::Index2Tuple, conjA::Symbol,
-                         B::AbstractArray, pB::Index2Tuple, conjB::Symbol,
+                         A::Diagonal, pA::Index2Tuple, conjA::Bool,
+                         B::AbstractArray, pB::Index2Tuple, conjB::Bool,
                          pAB::Index2Tuple,
                          α::Number, β::Number, ::StridedNative)
     argcheck_tensorcontract(C, A, pA, B, pB, pAB)
@@ -41,8 +41,8 @@ function tensorcontract!(C::AbstractArray,
 end
 
 function tensorcontract!(C::AbstractArray,
-                         A::Diagonal, pA::Index2Tuple, conjA::Symbol,
-                         B::Diagonal, pB::Index2Tuple, conjB::Symbol,
+                         A::Diagonal, pA::Index2Tuple, conjA::Bool,
+                         B::Diagonal, pB::Index2Tuple, conjB::Bool,
                          pAB::Index2Tuple,
                          α::Number, β::Number, ::StridedNative)
     argcheck_tensorcontract(C, A, pA, B, pB, pAB)
@@ -85,8 +85,8 @@ function tensorcontract!(C::AbstractArray,
 end
 
 function tensorcontract!(C::Diagonal,
-                         A::Diagonal, pA::Index2Tuple, conjA::Symbol,
-                         B::Diagonal, pB::Index2Tuple, conjB::Symbol,
+                         A::Diagonal, pA::Index2Tuple, conjA::Bool,
+                         B::Diagonal, pB::Index2Tuple, conjB::Bool,
                          pAB::Index2Tuple,
                          α::Number, β::Number, ::StridedNative)
     argcheck_tensorcontract(C, A, pA, B, pB, pAB)
@@ -101,8 +101,8 @@ function tensorcontract!(C::Diagonal,
 end
 
 function _diagtensorcontract!(C::StridedView,
-                              A::StridedView, pA::Index2Tuple, conjA::Symbol,
-                              Bdiag::StridedView, pB::Index2Tuple, conjB::Symbol,
+                              A::StridedView, pA::Index2Tuple, conjA::Bool,
+                              Bdiag::StridedView, pB::Index2Tuple, conjB::Bool,
                               pAB::Index2Tuple, α::Number, β::Number)
     sizeA = i -> size(A, i)
     csizeA = sizeA.(pA[2])

--- a/src/implementation/functions.jl
+++ b/src/implementation/functions.jl
@@ -7,7 +7,7 @@
 # ------------------------------------------------------------------------------------------
 
 """
-    tensorcopy([IC=IA], A, IA, [conjA=:N, [α=1]])
+    tensorcopy([IC=IA], A, IA, [conjA=false, [α=1]])
     tensorcopy(A, pA::Index2Tuple, conjA, α) # expert mode
 
 Create a copy of `A`, where the dimensions of `A` are assigned indices from the
@@ -18,27 +18,27 @@ The result of this method is equivalent to `α * permutedims(A, pA)` where `pA` 
 permutation such that `IC = IA[pA]`. The implementation of `tensorcopy` is however more
 efficient on average, especially if `Threads.nthreads() > 1`.
 
-Optionally, the symbol `conjA` can be used to specify whether the input tensor should be
-conjugated (`:C`) or not (`:N`).
+Optionally, the flag `conjA` can be used to specify whether the input tensor should be
+conjugated (`true`) or not (`false`).
 
 See also [`tensorcopy!`](@ref).
 """
 function tensorcopy end
 
-function tensorcopy(IC::Tuple, A, IA::Tuple, conjA::Symbol=:N, α::Number=One())
+function tensorcopy(IC::Tuple, A, IA::Tuple, conjA::Bool=false, α::Number=One())
     pA = add_indices(IA, IC)
     return tensorcopy(A, pA, conjA, α)
 end
 # default `IC`
-function tensorcopy(A, IA, conjA::Symbol=:N, α::Number=One())
+function tensorcopy(A, IA, conjA::Bool=false, α::Number=One())
     return tensorcopy(tuple(IA...), A, tuple(IA...), conjA, α)
 end
 # implement for iterables
-function tensorcopy(IC, A, IA, conjA::Symbol=:N, α::Number=One())
+function tensorcopy(IC, A, IA, conjA::Bool=false, α::Number=One())
     return tensorcopy(tuple(IC...), A, tuple(IA...), conjA, α)
 end
 # expert mode
-function tensorcopy(A, pA::Index2Tuple, conjA::Symbol=:N, α::Number=One(),
+function tensorcopy(A, pA::Index2Tuple, conjA::Bool=false, α::Number=One(),
                     backend::Backend...)
     TC = promote_add(scalartype(A), scalartype(α))
     C = tensoralloc_add(TC, A, pA, conjA)
@@ -46,22 +46,22 @@ function tensorcopy(A, pA::Index2Tuple, conjA::Symbol=:N, α::Number=One(),
 end
 
 """
-    tensorcopy!(C, A, pA::Index2Tuple, conjA=:N, α=1, [backend])
+    tensorcopy!(C, A, pA::Index2Tuple, conjA=false, α=1, [backend])
 
 Copy the contents of tensor `A` into `C`, where the dimensions `A` are permuted according to
 the permutation and repartition `pA`.
 
 The result of this method is equivalent to `α * permutedims!(C, A, pA)`.
 
-Optionally, the symbol `conjA` can be used to specify whether the input tensor should be
-conjugated (`:C`) or not (`:N`).
+Optionally, the flag `conjA` can be used to specify whether the input tensor should be
+conjugated (`true`) or not (`false`).
 
 !!! warning 
     The object `C` must not be aliased with `A`.
 
 See also [`tensorcopy`](@ref) and [`tensoradd!`](@ref)
 """
-function tensorcopy!(C, A, pA::Index2Tuple, conjA::Symbol=:N, α::Number=One(),
+function tensorcopy!(C, A, pA::Index2Tuple, conjA::Bool=false, α::Number=One(),
                      backend::Backend...)
     return tensoradd!(C, A, pA, conjA, α, false, backend...)
 end
@@ -82,37 +82,37 @@ that `IC = IA[pA]` (`IB[pB]`). The implementation of `tensoradd` is however more
 on average, as the temporary permuted arrays are not created.
 
 Optionally, the symbols `conjA` and `conjB` can be used to specify whether the input tensors
-should be conjugated (`:C`) or not (`:N`).
+should be conjugated (`true`) or not (`false`).
 
 See also [`tensoradd!`](@ref).
 """
 function tensoradd end
 
-function tensoradd(IC::Tuple, A, IA::Tuple, conjA::Symbol, B, IB::Tuple,
-                   conjB::Symbol, α::Number=One(), β::Number=One())
+function tensoradd(IC::Tuple, A, IA::Tuple, conjA::Bool, B, IB::Tuple,
+                   conjB::Bool, α::Number=One(), β::Number=One())
     return tensoradd(A, add_indices(IA, IC), conjA, B, add_indices(IB, IC), conjB, α, β)
 end
 # default `IC`
-function tensoradd(A, IA, conjA::Symbol, B, IB, conjB::Symbol,
+function tensoradd(A, IA, conjA::Bool, B, IB, conjB::Bool,
                    α::Number=One(), β::Number=One())
     return tensoradd(tuple(IA...), A, tuple(IA...), conjA, B, tuple(IB...), conjB, α, β)
 end
 # default `conjA` and `conjB`
 function tensoradd(IC, A, IA, B, IB, α::Number=One(), β::Number=One())
-    return tensoradd(tuple(IC...), A, tuple(IA...), :N, B, tuple(IB...), :N, α, β)
+    return tensoradd(tuple(IC...), A, tuple(IA...), false, B, tuple(IB...), false, α, β)
 end
 # default `IC`, `conjA` and `conjB`
 function tensoradd(A, IA, B, IB, α::Number=One(), β::Number=One())
     return tensoradd(tuple(IA...), A, tuple(IA...), B, tuple(IB...), α, β)
 end
 # iterables
-function tensoradd(IC, A, IA, conjA::Symbol, B, IB, conjB::Symbol,
+function tensoradd(IC, A, IA, conjA::Bool, B, IB, conjB::Bool,
                    α::Number=One(), β::Number=One())
     return tensoradd(tuple(IC...), A, tuple(IA...), conjA, B, tuple(IB...), conjB, α, β)
 end
 # expert mode
-function tensoradd(A, pA::Index2Tuple, conjA::Symbol,
-                   B, pB::Index2Tuple, conjB::Symbol,
+function tensoradd(A, pA::Index2Tuple, conjA::Bool,
+                   B, pB::Index2Tuple, conjB::Bool,
                    α::Number=One(), β::Number=One(), backend::Backend...)
     TC = promote_add(scalartype(A), scalartype(B), scalartype(α), scalartype(β))
     C = tensoralloc_add(TC, A, pA, conjA)
@@ -142,24 +142,24 @@ See also [`tensortrace!`](@ref).
 function tensortrace end
 
 # default `IC`
-function tensortrace(A, IA, conjA::Symbol, α::Number=One())
+function tensortrace(A, IA, conjA::Bool, α::Number=One())
     return tensortrace(unique2(tuple(IA...)), A, tuple(IA...), conjA, α)
 end
 # default `conjA`
 function tensortrace(IC, A, IA, α::Number=One())
-    return tensortrace(tuple(IC...), A, tuple(IA...), :N, α)
+    return tensortrace(tuple(IC...), A, tuple(IA...), false, α)
 end
 # default `IC` and `conjA`
 function tensortrace(A, IA, α::Number=One())
-    return tensortrace(unique2(tuple(IA...)), A, tuple(IA...), :N, α)
+    return tensortrace(unique2(tuple(IA...)), A, tuple(IA...), false, α)
 end
 # labels to indices
-function tensortrace(IC, A, IA, conjA::Symbol, α::Number=One())
+function tensortrace(IC, A, IA, conjA::Bool, α::Number=One())
     p, q = trace_indices(tuple(IA...), tuple(IC...))
     return tensortrace(A, p, q, conjA, α)
 end
 # expert mode
-function tensortrace(A, p::Index2Tuple, q::Index2Tuple, conjA::Symbol, α::Number=One(),
+function tensortrace(A, p::Index2Tuple, q::Index2Tuple, conjA::Bool, α::Number=One(),
                      backend::Backend...)
     TC = promote_contract(scalartype(A), scalartype(α))
     C = tensoralloc_add(TC, A, p, conjA)
@@ -190,32 +190,32 @@ See also [`tensorcontract!`](@ref).
 """
 function tensorcontract end
 
-function tensorcontract(IC::Tuple, A, IA::Tuple, conjA::Symbol, B, IB::Tuple, conjB::Symbol,
+function tensorcontract(IC::Tuple, A, IA::Tuple, conjA::Bool, B, IB::Tuple, conjB::Bool,
                         α::Number=One())
     pA, pB, pAB = contract_indices(IA, IB, IC)
     return tensorcontract(A, pA, conjA, B, pB, conjB, pAB, α)
 end
 # default `IC`
-function tensorcontract(A, IA, conjA, B, IB, conjB, α::Number=One())
+function tensorcontract(A, IA, conjA::Bool, B, IB, conjB::Bool, α::Number=One())
     return tensorcontract(symdiff(tuple(IA...), tuple(IB...)), A, tuple(IA...), conjA, B,
                           tuple(IB...), conjB, α)
 end
 # default `conjA` and `conjB`
 function tensorcontract(IC, A, IA, B, IB, α::Number=One())
-    return tensorcontract(tuple(IC...), A, tuple(IA...), :N, B, tuple(IB...), :N, α)
+    return tensorcontract(tuple(IC...), A, tuple(IA...), false, B, tuple(IB...), false, α)
 end
 # default `IC`, `conjA` and `conjB`
 function tensorcontract(A, IA, B, IB, α::Number=One())
-    return tensorcontract(symdiff(tuple(IA...), tuple(IB...)), A, tuple(IA...), :N, B,
-                          tuple(IB...), :N, α)
+    return tensorcontract(symdiff(tuple(IA...), tuple(IB...)), A, tuple(IA...), false, B,
+                          tuple(IB...), false, α)
 end
 # iterables
-function tensorcontract(IC, A, IA, conjA::Symbol, B, IB, conjB::Symbol, α::Number=One())
+function tensorcontract(IC, A, IA, conjA::Bool, B, IB, conjB::Bool, α::Number=One())
     return tensorcontract(tuple(IC...), A, tuple(IA...), conjA, B, tuple(IB...), conjB, α)
 end
 # expert mode
-function tensorcontract(A, pA::Index2Tuple, conjA::Symbol,
-                        B, pB::Index2Tuple, conjB::Symbol,
+function tensorcontract(A, pA::Index2Tuple, conjA::Bool,
+                        B, pB::Index2Tuple, conjB::Bool,
                         pAB::Index2Tuple, α::Number=One(), backend::Backend...)
     TC = promote_contract(scalartype(A), scalartype(B), scalartype(α))
     C = tensoralloc_contract(TC, A, pA, conjA, B, pB, conjB, pAB)
@@ -244,32 +244,32 @@ See also [`tensorproduct!`](@ref) and [`tensorcontract`](@ref).
 """
 function tensorproduct end
 
-function tensorproduct(IC::Tuple, A, IA::Tuple, conjA::Symbol, B, IB::Tuple, conjB::Symbol,
+function tensorproduct(IC::Tuple, A, IA::Tuple, conjA::Bool, B, IB::Tuple, conjB::Bool,
                        α::Number=One())
     pA, pB, pAB = contract_indices(IA, IB, IC)
     return tensorproduct(A, pA, conjA, B, pB, conjB, pAB, α)
 end
 # default `IC`
-function tensorproduct(A, IA, conjA::Symbol, B, IB, conjB::Symbol, α::Number=One())
+function tensorproduct(A, IA, conjA::Bool, B, IB, conjB::Bool, α::Number=One())
     return tensorproduct(vcat(tuple(IA...), tuple(IB...)), A, tuple(IA...), conjA, B,
                          tuple(IB...), conjB, α)
 end
 # default `conjA` and `conjB`
 function tensorproduct(IC, A, IA, B, IB, α::Number=One())
-    return tensorproduct(tuple(IC...), A, tuple(IA...), :N, B, tuple(IB...), :N, α)
+    return tensorproduct(tuple(IC...), A, tuple(IA...), false, B, tuple(IB...), false, α)
 end
 # default `IC`, `conjA` and `conjB`
 function tensorproduct(A, IA, B, IB, α::Number=One())
-    return tensorproduct(vcat(tuple(IA...), tuple(IB...)), A, tuple(IA...), :N, B,
-                         tuple(IB...), :N, α)
+    return tensorproduct(vcat(tuple(IA...), tuple(IB...)), A, tuple(IA...), false, B,
+                         tuple(IB...), false, α)
 end
 # iterables
-function tensorproduct(IC, A, IA, conjA::Symbol, B, IB, conjB::Symbol, α::Number=One())
+function tensorproduct(IC, A, IA, conjA::Bool, B, IB, conjB::Bool, α::Number=One())
     return tensorproduct(tuple(IC...), A, tuple(IA...), conjA, B, tuple(IB...), conjB, α)
 end
 # expert mode
-function tensorproduct(A, pA::Index2Tuple, conjA::Symbol,
-                       B, pB::Index2Tuple, conjB::Symbol,
+function tensorproduct(A, pA::Index2Tuple, conjA::Bool,
+                       B, pB::Index2Tuple, conjB::Bool,
                        pAB::Index2Tuple, α::Number=One(), backend::Backend...)
     numin(pA) == 0 && numout(pB) == 0 ||
         throw(IndexError("not a valid tensor product"))
@@ -289,8 +289,8 @@ the indices indeed specify a tensor product instead of a genuine contraction.
 See als [`tensorproduct`](@ref) and [`tensorcontract!`](@ref).
 """
 function tensorproduct!(C,
-                        A, pA::Index2Tuple, conjA::Symbol,
-                        B, pB::Index2Tuple, conjB::Symbol,
+                        A, pA::Index2Tuple, conjA::Bool,
+                        B, pB::Index2Tuple, conjB::Bool,
                         pAB::Index2Tuple,
                         α::Number=One(), β::Number=Zero(), backend::Backend...)
     numin(pA) == 0 && numout(pB) == 0 ||

--- a/src/implementation/functions.jl
+++ b/src/implementation/functions.jl
@@ -1,7 +1,6 @@
 # methods/simple.jl
 #
 # Method-based access to tensor operations using simple definitions.
-
 # ------------------------------------------------------------------------------------------
 # tensorcopy
 # ------------------------------------------------------------------------------------------
@@ -25,17 +24,13 @@ See also [`tensorcopy!`](@ref).
 """
 function tensorcopy end
 
-function tensorcopy(IC::Tuple, A, IA::Tuple, conjA::Bool=false, α::Number=One())
+function tensorcopy(IC::Labels, A, IA::Labels, conjA::Bool=false, α::Number=One())
     pA = add_indices(IA, IC)
     return tensorcopy(A, pA, conjA, α)
 end
 # default `IC`
-function tensorcopy(A, IA, conjA::Bool=false, α::Number=One())
-    return tensorcopy(tuple(IA...), A, tuple(IA...), conjA, α)
-end
-# implement for iterables
-function tensorcopy(IC, A, IA, conjA::Bool=false, α::Number=One())
-    return tensorcopy(tuple(IC...), A, tuple(IA...), conjA, α)
+function tensorcopy(A, IA::Labels, conjA::Bool=false, α::Number=One())
+    return tensorcopy(IA, A, IA, conjA, α)
 end
 # expert mode
 function tensorcopy(A, pA::Index2Tuple, conjA::Bool=false, α::Number=One(),
@@ -88,27 +83,23 @@ See also [`tensoradd!`](@ref).
 """
 function tensoradd end
 
-function tensoradd(IC::Tuple, A, IA::Tuple, conjA::Bool, B, IB::Tuple,
+function tensoradd(IC::Labels, A, IA::Labels, conjA::Bool, B, IB::Labels,
                    conjB::Bool, α::Number=One(), β::Number=One())
     return tensoradd(A, add_indices(IA, IC), conjA, B, add_indices(IB, IC), conjB, α, β)
 end
 # default `IC`
-function tensoradd(A, IA, conjA::Bool, B, IB, conjB::Bool,
+function tensoradd(A, IA::Labels, conjA::Bool, B, IB::Labels, conjB::Bool,
                    α::Number=One(), β::Number=One())
-    return tensoradd(tuple(IA...), A, tuple(IA...), conjA, B, tuple(IB...), conjB, α, β)
+    return tensoradd(IA, A, IA, conjA, B, IB, conjB, α, β)
 end
 # default `conjA` and `conjB`
-function tensoradd(IC, A, IA, B, IB, α::Number=One(), β::Number=One())
-    return tensoradd(tuple(IC...), A, tuple(IA...), false, B, tuple(IB...), false, α, β)
+function tensoradd(IC::Labels, A, IA::Labels, B, IB::Labels, α::Number=One(),
+                   β::Number=One())
+    return tensoradd(IC, A, IA, false, B, IB, false, α, β)
 end
 # default `IC`, `conjA` and `conjB`
-function tensoradd(A, IA, B, IB, α::Number=One(), β::Number=One())
-    return tensoradd(tuple(IA...), A, tuple(IA...), B, tuple(IB...), α, β)
-end
-# iterables
-function tensoradd(IC, A, IA, conjA::Bool, B, IB, conjB::Bool,
-                   α::Number=One(), β::Number=One())
-    return tensoradd(tuple(IC...), A, tuple(IA...), conjA, B, tuple(IB...), conjB, α, β)
+function tensoradd(A, IA::Labels, B, IB::Labels, α::Number=One(), β::Number=One())
+    return tensoradd(IA, A, IA, B, IB, α, β)
 end
 # expert mode
 function tensoradd(A, pA::Index2Tuple, conjA::Bool,
@@ -142,20 +133,20 @@ See also [`tensortrace!`](@ref).
 function tensortrace end
 
 # default `IC`
-function tensortrace(A, IA, conjA::Bool, α::Number=One())
-    return tensortrace(unique2(tuple(IA...)), A, tuple(IA...), conjA, α)
+function tensortrace(A, IA::Labels, conjA::Bool, α::Number=One())
+    return tensortrace(unique2(IA), A, IA, conjA, α)
 end
 # default `conjA`
-function tensortrace(IC, A, IA, α::Number=One())
-    return tensortrace(tuple(IC...), A, tuple(IA...), false, α)
+function tensortrace(IC::Labels, A, IA::Labels, α::Number=One())
+    return tensortrace(IC, A, IA, false, α)
 end
 # default `IC` and `conjA`
-function tensortrace(A, IA, α::Number=One())
-    return tensortrace(unique2(tuple(IA...)), A, tuple(IA...), false, α)
+function tensortrace(A, IA::Labels, α::Number=One())
+    return tensortrace(unique2(IA), A, IA, false, α)
 end
 # labels to indices
-function tensortrace(IC, A, IA, conjA::Bool, α::Number=One())
-    p, q = trace_indices(tuple(IA...), tuple(IC...))
+function tensortrace(IC::Labels, A, IA::Labels, conjA::Bool, α::Number=One())
+    p, q = trace_indices(IA, IC)
     return tensortrace(A, p, q, conjA, α)
 end
 # expert mode
@@ -190,28 +181,23 @@ See also [`tensorcontract!`](@ref).
 """
 function tensorcontract end
 
-function tensorcontract(IC::Tuple, A, IA::Tuple, conjA::Bool, B, IB::Tuple, conjB::Bool,
+function tensorcontract(IC::Labels, A, IA::Labels, conjA::Bool, B, IB::Labels, conjB::Bool,
                         α::Number=One())
     pA, pB, pAB = contract_indices(IA, IB, IC)
     return tensorcontract(A, pA, conjA, B, pB, conjB, pAB, α)
 end
 # default `IC`
-function tensorcontract(A, IA, conjA::Bool, B, IB, conjB::Bool, α::Number=One())
-    return tensorcontract(symdiff(tuple(IA...), tuple(IB...)), A, tuple(IA...), conjA, B,
-                          tuple(IB...), conjB, α)
+function tensorcontract(A, IA::Labels, conjA::Bool, B, IB::Labels, conjB::Bool,
+                        α::Number=One())
+    return tensorcontract(symdiff(IA, IB), A, IA, conjA, B, IB, conjB, α)
 end
 # default `conjA` and `conjB`
-function tensorcontract(IC, A, IA, B, IB, α::Number=One())
-    return tensorcontract(tuple(IC...), A, tuple(IA...), false, B, tuple(IB...), false, α)
+function tensorcontract(IC::Labels, A, IA::Labels, B, IB::Labels, α::Number=One())
+    return tensorcontract(IC, A, IA, false, B, IB, false, α)
 end
 # default `IC`, `conjA` and `conjB`
-function tensorcontract(A, IA, B, IB, α::Number=One())
-    return tensorcontract(symdiff(tuple(IA...), tuple(IB...)), A, tuple(IA...), false, B,
-                          tuple(IB...), false, α)
-end
-# iterables
-function tensorcontract(IC, A, IA, conjA::Bool, B, IB, conjB::Bool, α::Number=One())
-    return tensorcontract(tuple(IC...), A, tuple(IA...), conjA, B, tuple(IB...), conjB, α)
+function tensorcontract(A, IA::Labels, B, IB::Labels, α::Number=One())
+    return tensorcontract(symdiff(IA, IB), A, IA, false, B, IB, false, α)
 end
 # expert mode
 function tensorcontract(A, pA::Index2Tuple, conjA::Bool,
@@ -244,28 +230,23 @@ See also [`tensorproduct!`](@ref) and [`tensorcontract`](@ref).
 """
 function tensorproduct end
 
-function tensorproduct(IC::Tuple, A, IA::Tuple, conjA::Bool, B, IB::Tuple, conjB::Bool,
+function tensorproduct(IC::Labels, A, IA::Labels, conjA::Bool, B, IB::Labels, conjB::Bool,
                        α::Number=One())
     pA, pB, pAB = contract_indices(IA, IB, IC)
     return tensorproduct(A, pA, conjA, B, pB, conjB, pAB, α)
 end
 # default `IC`
-function tensorproduct(A, IA, conjA::Bool, B, IB, conjB::Bool, α::Number=One())
-    return tensorproduct(vcat(tuple(IA...), tuple(IB...)), A, tuple(IA...), conjA, B,
-                         tuple(IB...), conjB, α)
+function tensorproduct(A, IA::Labels, conjA::Bool, B, IB::Labels, conjB::Bool,
+                       α::Number=One())
+    return tensorproduct(vcat(IA, IB), A, IA, conjA, B, IB, conjB, α)
 end
 # default `conjA` and `conjB`
-function tensorproduct(IC, A, IA, B, IB, α::Number=One())
-    return tensorproduct(tuple(IC...), A, tuple(IA...), false, B, tuple(IB...), false, α)
+function tensorproduct(IC::Labels, A, IA::Labels, B, IB::Labels, α::Number=One())
+    return tensorproduct(IC, A, IA, false, B, IB, false, α)
 end
 # default `IC`, `conjA` and `conjB`
-function tensorproduct(A, IA, B, IB, α::Number=One())
-    return tensorproduct(vcat(tuple(IA...), tuple(IB...)), A, tuple(IA...), false, B,
-                         tuple(IB...), false, α)
-end
-# iterables
-function tensorproduct(IC, A, IA, conjA::Bool, B, IB, conjB::Bool, α::Number=One())
-    return tensorproduct(tuple(IC...), A, tuple(IA...), conjA, B, tuple(IB...), conjB, α)
+function tensorproduct(A, IA::Labels, B, IB::Labels, α::Number=One())
+    return tensorproduct(vcat(IA, IB), A, IA, false, B, IB, false, α)
 end
 # expert mode
 function tensorproduct(A, pA::Index2Tuple, conjA::Bool,

--- a/src/implementation/indices.jl
+++ b/src/implementation/indices.jl
@@ -56,6 +56,7 @@ end
 #-------------------------------------------------------------------------------------------
 # Extract index information
 #-------------------------------------------------------------------------------------------
+add_indices(IA, IC) = add_indices(tuple(IA...), tuple(IC...))
 function add_indices(IA::NTuple{NA,Any}, IC::NTuple{NC,Any}) where {NA,NC}
     indCinA = map(l -> _findfirst(isequal(l), IA), IC)
     (NA == NC && isperm(indCinA)) ||
@@ -63,6 +64,7 @@ function add_indices(IA::NTuple{NA,Any}, IC::NTuple{NC,Any}) where {NA,NC}
     return (indCinA, ())
 end
 
+trace_indices(IA, IC) = trace_indices(tuple(IA...), tuple(IC...))
 function trace_indices(IA::NTuple{NA,Any}, IC::NTuple{NC,Any}) where {NA,NC}
     # trace indices
     isodd(length(IA) - length(IC)) &&
@@ -79,6 +81,9 @@ function trace_indices(IA::NTuple{NA,Any}, IC::NTuple{NC,Any}) where {NA,NC}
     return (indCinA, ()), (cindA1, cindA2)
 end
 
+function contract_indices(IA, IB, IC)
+    return contract_indices(tuple(IA...), tuple(IB...), tuple(IC...))
+end
 function contract_indices(IA::NTuple{NA,Any}, IB::NTuple{NB,Any},
                           IC::NTuple{NC,Any}) where {NA,NB,NC}
     # labels

--- a/src/implementation/ncon.jl
+++ b/src/implementation/ncon.jl
@@ -32,9 +32,9 @@ function ncon(tensors, network,
 
     if length(tensors) == 1
         if length(output′) == length(network[1])
-            return tensorcopy(output′, tensors[1], network[1], conjlist[1] ? :C : :N)
+            return tensorcopy(output′, tensors[1], network[1], conjlist[1])
         else
-            return tensortrace(output′, tensors[1], network[1], conjlist[1] ? :C : :N)
+            return tensortrace(output′, tensors[1], network[1], conjlist[1])
         end
     end
 
@@ -51,13 +51,13 @@ end
 function contracttree(tensors, network, conjlist, tree)
     @nospecialize
     if tree isa Int
-        return tensors[tree], tuple(network[tree]...), (conjlist[tree] ? :C : :N)
+        return tensors[tree], tuple(network[tree]...), (conjlist[tree])
     end
     A, IA, CA = contracttree(tensors, network, conjlist, tree[1])
     B, IB, CB = contracttree(tensors, network, conjlist, tree[2])
     IC = tuple(symdiff(IA, IB)...)
     C = tensorcontract(IC, A, IA, CA, B, IB, CB)
-    return C, IC, :N
+    return C, IC, false
 end
 
 function nconoutput(network, output)

--- a/src/implementation/strided.jl
+++ b/src/implementation/strided.jl
@@ -63,7 +63,7 @@ function tensortrace!(C::StridedView,
     return C
 end
 
-function tensorcontract!(C::StridedView{T},
+function tensorcontract!(C::StridedView,
                          A::StridedView, pA::Index2Tuple, conjA::Bool,
                          B::StridedView, pB::Index2Tuple, conjB::Bool,
                          pAB::Index2Tuple,

--- a/src/indexnotation/preprocessors.jl
+++ b/src/indexnotation/preprocessors.jl
@@ -147,7 +147,7 @@ function insertcontractionchecks(ex)
             (object, indl, indr) = decomposegeneraltensor(getlhs(ex))
             inds = vcat(indl, indr)
             for (pos, label) in enumerate(inds)
-                push!(get!(indexmap, label, Vector{Any}()), (object, pos, :C)) # treat lhs as conjugated tensor
+                push!(get!(indexmap, label, Vector{Any}()), (object, pos, true)) # treat lhs as conjugated tensor
             end
         end
         _fillindexmap!(indexmap, rhs)
@@ -158,9 +158,9 @@ function insertcontractionchecks(ex)
             for k in 2:length(v)
                 obj2, pos2, conj2 = v[k]
                 push!(out.args,
-                      :(@notensor checkcontractible($obj1, $pos1, $(QuoteNode(conj1)),
+                      :(@notensor checkcontractible($obj1, $pos1, $conj1,
                                                     $obj2, $pos2,
-                                                    $(QuoteNode(conj2)), $l)))
+                                                    $conj2, $l)))
             end
         end
         return Expr(:block, out, ex)
@@ -172,7 +172,7 @@ function _fillindexmap!(indexmap, ex)
         (object, indl, indr, _, conj) = decomposegeneraltensor(ex)
         inds = vcat(indl, indr)
         for (pos, label) in enumerate(inds)
-            push!(get!(indexmap, label, Vector{Any}()), (object, pos, conj ? :C : :N))
+            push!(get!(indexmap, label, Vector{Any}()), (object, pos, conj))
         end
     elseif ex isa Expr
         for exa in ex.args

--- a/src/indices.jl
+++ b/src/indices.jl
@@ -34,3 +34,17 @@ end
 
 istrivialpermutation(p::IndexTuple) = p == trivialpermutation(p)
 istrivialpermutation(p::Index2Tuple) = p == trivialpermutation(p)
+
+"""
+    const LabelType = Union{Int,Symbol,Char}
+
+Alias for supported label types.
+"""
+const LabelType = Union{Int,Symbol,Char}
+
+"""
+    const Labels{I<:LabelType} = Union{Tuple{Vararg{I}},Vector{I}}
+
+Alias for supported label containers.
+"""
+const Labels{I<:LabelType} = Union{Tuple{Vararg{I}},AbstractVector{I}}

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -16,7 +16,7 @@ See also [`tensoradd`](@ref).
 """
 function tensoradd! end
 # insert default α and β arguments
-function tensoradd!(C, A, pA::Index2Tuple, conjA::Symbol)
+function tensoradd!(C, A, pA::Index2Tuple, conjA::Bool)
     return tensoradd!(C, A, pA, conjA, One(), One())
 end
 
@@ -36,7 +36,7 @@ See also [`tensortrace`](@ref).
 """
 function tensortrace! end
 # insert default α and β arguments
-function tensortrace!(C, A, p::Index2Tuple, q::Index2Tuple, conjA::Symbol)
+function tensortrace!(C, A, p::Index2Tuple, q::Index2Tuple, conjA::Bool)
     return tensortrace!(C, A, p, q, conjA, One(), Zero())
 end
 
@@ -58,8 +58,8 @@ See also [`tensorcontract`](@ref).
 function tensorcontract! end
 # insert default α and β arguments
 function tensorcontract!(C,
-                         A, pA::Index2Tuple, conjA::Symbol,
-                         B, pB::Index2Tuple, conjB::Symbol,
+                         A, pA::Index2Tuple, conjA::Bool,
+                         B, pB::Index2Tuple, conjB::Bool,
                          pAB::Index2Tuple)
     return tensorcontract!(C, A, pA, conjA, B, pB, conjB, pAB, One(), Zero())
 end

--- a/test/ad.jl
+++ b/test/ad.jl
@@ -21,11 +21,11 @@ precision(::Type{<:Union{Float64,Complex{Float64}}}) = 1e-8
     A = rand(T₁, (2, 3, 4, 2, 5))
     C = rand(T₂, size.(Ref(A), p[1]))
 
-    test_rrule(tensortrace!, C, A, p, q, :N, α, β; atol, rtol)
-    test_rrule(tensortrace!, C, A, p, q, :C, α, β; atol, rtol)
+    test_rrule(tensortrace!, C, A, p, q, false, α, β; atol, rtol)
+    test_rrule(tensortrace!, C, A, p, q, true, α, β; atol, rtol)
 
-    test_rrule(tensortrace!, C, A, p, q, :C, α, β, StridedBLAS(); atol, rtol)
-    test_rrule(tensortrace!, C, A, p, q, :N, α, β, StridedNative(); atol, rtol)
+    test_rrule(tensortrace!, C, A, p, q, true, α, β, StridedBLAS(); atol, rtol)
+    test_rrule(tensortrace!, C, A, p, q, false, α, β, StridedNative(); atol, rtol)
 end
 
 @testset "tensoradd! ($T₁, $T₂)" for (T₁, T₂) in ((Float64, Float64), (Float32, Float64),
@@ -39,11 +39,11 @@ end
     C = rand(T₂, size.(Ref(A), pA[1]))
     α = rand(T)
     β = rand(T)
-    test_rrule(tensoradd!, C, A, pA, :N, α, β; atol, rtol)
-    test_rrule(tensoradd!, C, A, pA, :C, α, β; atol, rtol)
+    test_rrule(tensoradd!, C, A, pA, false, α, β; atol, rtol)
+    test_rrule(tensoradd!, C, A, pA, true, α, β; atol, rtol)
 
-    test_rrule(tensoradd!, C, A, pA, :N, α, β, StridedBLAS(); atol, rtol)
-    test_rrule(tensoradd!, C, A, pA, :C, α, β, StridedNative(); atol, rtol)
+    test_rrule(tensoradd!, C, A, pA, false, α, β, StridedBLAS(); atol, rtol)
+    test_rrule(tensoradd!, C, A, pA, true, α, β, StridedNative(); atol, rtol)
 end
 
 @testset "tensorcontract! ($T₁, $T₂)" for (T₁, T₂) in
@@ -63,14 +63,14 @@ end
     α = randn(T)
     β = randn(T)
 
-    test_rrule(tensorcontract!, C, A, pA, :N, B, pB, :N, pAB, α, β; atol, rtol)
-    test_rrule(tensorcontract!, C, A, pA, :C, B, pB, :N, pAB, α, β; atol, rtol)
-    test_rrule(tensorcontract!, C, A, pA, :N, B, pB, :C, pAB, α, β; atol, rtol)
-    test_rrule(tensorcontract!, C, A, pA, :C, B, pB, :C, pAB, α, β; atol, rtol)
+    test_rrule(tensorcontract!, C, A, pA, false, B, pB, false, pAB, α, β; atol, rtol)
+    test_rrule(tensorcontract!, C, A, pA, true, B, pB, false, pAB, α, β; atol, rtol)
+    test_rrule(tensorcontract!, C, A, pA, false, B, pB, true, pAB, α, β; atol, rtol)
+    test_rrule(tensorcontract!, C, A, pA, true, B, pB, true, pAB, α, β; atol, rtol)
 
-    test_rrule(tensorcontract!, C, A, pA, :N, B, pB, :N, pAB, α, β, StridedBLAS();
+    test_rrule(tensorcontract!, C, A, pA, false, B, pB, false, pAB, α, β, StridedBLAS();
                atol, rtol)
-    test_rrule(tensorcontract!, C, A, pA, :C, B, pB, :N, pAB, α, β, StridedNative();
+    test_rrule(tensorcontract!, C, A, pA, true, B, pB, false, pAB, α, β, StridedNative();
                atol, rtol)
 end
 

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -81,7 +81,7 @@ using TensorOperations: IndexError
 
         A = rand(1, 2)
         B = rand(4, 5)
-        C1 = tensorcontract((-1, -2, -3, -4), A, (-3, -1), :N, B, (-2, -4), :N)
+        C1 = tensorcontract((-1, -2, -3, -4), A, (-3, -1), false, B, (-2, -4), false)
         C2 = zeros(2, 4, 1, 5)
         for i in axes(C2, 1), j in axes(C2, 2), k in axes(C2, 3), l in axes(C2, 4)
             C2[i, j, k, l] = A[k, i] * B[j, l]
@@ -103,12 +103,12 @@ using TensorOperations: IndexError
         Acopy = tensorcopy(A, 1:4)
         Ccopy = tensorcopy(C, 1:4)
         pC = (p, ())
-        tensorcopy!(C, A, pC, :N)
-        tensorcopy!(Ccopy, Acopy, pC, :N)
+        tensorcopy!(C, A, pC, false)
+        tensorcopy!(Ccopy, Acopy, pC, false)
         @test C ≈ Ccopy
-        @test_throws IndexError tensorcopy!(C, A, ((1, 2, 3), ()), :N)
-        @test_throws DimensionMismatch tensorcopy!(C, A, ((1, 2, 3, 4), ()), :N)
-        @test_throws IndexError tensorcopy!(C, A, ((1, 2, 2, 3), ()), :N)
+        @test_throws IndexError tensorcopy!(C, A, ((1, 2, 3), ()), false)
+        @test_throws DimensionMismatch tensorcopy!(C, A, ((1, 2, 3, 4), ()), false)
+        @test_throws IndexError tensorcopy!(C, A, ((1, 2, 2, 3), ()), false)
     end
 
     @testset "tensoradd!" begin
@@ -121,12 +121,12 @@ using TensorOperations: IndexError
         Ccopy = tensorcopy(1:4, C, 1:4)
         α = randn(Float64)
         β = randn(Float64)
-        tensoradd!(C, A, (p, ()), :N, α, β)
+        tensoradd!(C, A, (p, ()), false, α, β)
         Ccopy = β * Ccopy + α * Acopy
         @test C ≈ Ccopy
-        @test_throws IndexError tensoradd!(C, A, ((1, 2, 3), ()), :N, 1.2, 0.5)
-        @test_throws DimensionMismatch tensoradd!(C, A, ((1, 2, 3, 4), ()), :N, 1.2, 0.5)
-        @test_throws IndexError tensoradd!(C, A, ((1, 1, 2, 3), ()), :N, 1.2, 0.5)
+        @test_throws IndexError tensoradd!(C, A, ((1, 2, 3), ()), false, 1.2, 0.5)
+        @test_throws DimensionMismatch tensoradd!(C, A, ((1, 2, 3, 4), ()), false, 1.2, 0.5)
+        @test_throws IndexError tensoradd!(C, A, ((1, 1, 2, 3), ()), false, 1.2, 0.5)
     end
 
     @testset "tensortrace!" begin
@@ -138,18 +138,19 @@ using TensorOperations: IndexError
         Bcopy = tensorcopy(B, 1:2)
         α = randn(Float64)
         β = randn(Float64)
-        tensortrace!(B, A, ((2, 3), ()), ((1,), (4,)), :N, α, β)
+        tensortrace!(B, A, ((2, 3), ()), ((1,), (4,)), false, α, β)
         Bcopy = β * Bcopy
         for i in 1 .+ (0:8)
             Bcopy += α * view(A, i, :, :, i)
         end
         @test B ≈ Bcopy
-        @test_throws IndexError tensortrace!(B, A, ((1,), ()), ((2,), (3,)), :N, α, β)
-        @test_throws DimensionMismatch tensortrace!(B, A, ((1, 4), ()), ((2,), (3,)), :N, α,
-                                                    β)
-        @test_throws IndexError tensortrace!(B, A, ((1, 4), ()), ((1, 1), (4,)), :N, α, β)
-        @test_throws DimensionMismatch tensortrace!(B, A, ((1, 4), ()), ((1,), (3,)), :N, α,
-                                                    β)
+        @test_throws IndexError tensortrace!(B, A, ((1,), ()), ((2,), (3,)), false, α, β)
+        @test_throws DimensionMismatch tensortrace!(B, A, ((1, 4), ()), ((2,), (3,)), false,
+                                                    α, β)
+        @test_throws IndexError tensortrace!(B, A, ((1, 4), ()), ((1, 1), (4,)), false, α,
+                                             β)
+        @test_throws DimensionMismatch tensortrace!(B, A, ((1, 4), ()), ((1,), (3,)), false,
+                                                    α, β)
     end
 
     @testset "tensorcontract!" begin
@@ -170,24 +171,24 @@ using TensorOperations: IndexError
                 Ccopy[d, a, e] += α * A[a, b, c, d] * conj(B[c, e, b])
             end
         end
-        tensorcontract!(C, A, ((4, 1), (2, 3)), :N, B, ((3, 1), (2,)), :C,
+        tensorcontract!(C, A, ((4, 1), (2, 3)), false, B, ((3, 1), (2,)), true,
                         ((1, 2, 3), ()), α, β)
         @test C ≈ Ccopy
         @test_throws IndexError tensorcontract!(C,
-                                                A, ((4, 1), (2, 4)), :N,
-                                                B, ((1, 3), (2,)), :N,
+                                                A, ((4, 1), (2, 4)), false,
+                                                B, ((1, 3), (2,)), false,
                                                 ((1, 2, 3), ()), α, β)
         @test_throws IndexError tensorcontract!(C,
-                                                A, ((4, 1), (2, 3)), :N,
-                                                B, ((1, 3), ()), :N,
+                                                A, ((4, 1), (2, 3)), false,
+                                                B, ((1, 3), ()), false,
                                                 ((1, 2, 3), ()), α, β)
         @test_throws IndexError tensorcontract!(C,
-                                                A, ((4, 1), (2, 3)), :N,
-                                                B, ((1, 3), (2,)), :N,
+                                                A, ((4, 1), (2, 3)), false,
+                                                B, ((1, 3), (2,)), false,
                                                 ((1, 2), ()), α, β)
         @test_throws DimensionMismatch tensorcontract!(C,
-                                                       A, ((4, 1), (2, 3)), :N,
-                                                       B, ((1, 3), (2,)), :N,
+                                                       A, ((4, 1), (2, 3)), false,
+                                                       B, ((1, 3), (2,)), false,
                                                        ((1, 3, 2), ()), α, β)
     end
 end


### PR DESCRIPTION
This PR simplifies the usage of conj flags by replacing the symbols with booleans. This is especially useful in AD, where comparing and negating with booleans is more convenient.

Importantly, as a `Bool` is a subtype of `Number`, this introduces some method ambiguities for the functions syntax, which is resolved by restricting the types of the labels to be a `Tuple` or `AbstractVector` of `Int`, `Symbol` or `Char`.