### PR TITLE
Alternative Allocators

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,6 @@ authors = [
 version = "5.0.0"
 
 [deps]
-Bumper = "8ce10254-0962-460f-a3d8-1f77fea1446e"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 LRUCache = "8ac3fa9e-de4c-5943-b1dc-09c6b5f20637"
@@ -22,11 +21,13 @@ VectorInterface = "409d34a3-91d5-4945-b6ec-7529ddf182d8"
 cuTENSOR = "011b41b2-24ef-40a8-b3eb-fa098493e9e1"
 
 [weakdeps]
+Bumper = "8ce10254-0962-460f-a3d8-1f77fea1446e"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 cuTENSOR = "011b41b2-24ef-40a8-b3eb-fa098493e9e1"
 
 [extensions]
+TensorOperationsBumperExt = "Bumper"
 TensorOperationsChainRulesCoreExt = "ChainRulesCore"
 TensorOperationscuTENSORExt = ["cuTENSOR", "CUDA"]
 
@@ -53,6 +54,7 @@ julia = "1.8"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+Bumper = "8ce10254-0962-460f-a3d8-1f77fea1446e"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 ChainRulesTestUtils = "cdddcdb0-9152-4a09-a978-84456f9df70a"
 DynamicPolynomials = "7c1d4256-1411-5781-91ec-d7bc3513ac07"
@@ -71,4 +73,5 @@ test = [
     "cuTENSOR",
     "Aqua",
     "Logging",
+    "Bumper",
 ]

--- a/Project.toml
+++ b/Project.toml
@@ -8,11 +8,13 @@ authors = [
 version = "5.0.0"
 
 [deps]
+Bumper = "8ce10254-0962-460f-a3d8-1f77fea1446e"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 LRUCache = "8ac3fa9e-de4c-5943-b1dc-09c6b5f20637"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 PackageExtensionCompat = "65ce6f38-6b18-4e1d-a461-8949797d7930"
+PtrArrays = "43287f4e-b6f4-7ad1-bb20-aadabca52c3d"
 Strided = "5e0ebb24-38b0-5f93-81fe-25c709ecae67"
 StridedViews = "4db3bf67-4bd7-4b4e-b153-31dc3fb37143"
 TupleTools = "9d95972d-f1c8-5527-a6e0-b4b365fa01f6"
@@ -30,6 +32,7 @@ TensorOperationscuTENSORExt = ["cuTENSOR", "CUDA"]
 
 [compat]
 Aqua = "0.6, 0.7, 0.8"
+Bumper = "0.6"
 CUDA = "5.4.0"
 ChainRulesCore = "1"
 ChainRulesTestUtils = "1"
@@ -38,6 +41,7 @@ LRUCache = "1"
 LinearAlgebra = "1.6"
 Logging = "1.6"
 PackageExtensionCompat = "1"
+PtrArrays = "1.2"
 Random = "1"
 Strided = "2.0.4"
 StridedViews = "0.3"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,6 +9,7 @@ makedocs(; modules=[TensorOperations],
                 "Manual" => ["man/indexnotation.md",
                              "man/functions.md",
                              "man/interface.md",
+                             "man/backends.md",
                              "man/autodiff.md",
                              "man/implementation.md"],
                 "Index" => "index/index.md"])

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,7 +5,7 @@
 ## Table of contents
 
 ```@contents
-Pages = ["index.md", "man/indexnotation.md", "man/functions.md", "man/autodiff.md", "man/interface.md", "man/implementation.md"]
+Pages = ["index.md", "man/indexnotation.md", "man/functions.md", "man/interface.md", "man/backends.md", "man/autodiff.md", "man/implementation.md"]
 Depth = 4
 ```
 
@@ -82,7 +82,5 @@ complicated tensor expression is deconstructed.
 
 ## To do list
 
-  - Add more backends, e.g. using pure Julia Base functionality, or using
-    [LoopVectorization.jl](https://github.com/JuliaSIMD/LoopVectorization.jl)
   - Make it easier to modify the contraction order algorithm or its cost function (e.g. to
     optimize based on memory footprint) or to splice in runtime information.

--- a/docs/src/man/backends.md
+++ b/docs/src/man/backends.md
@@ -1,0 +1,129 @@
+# Backends and Allocators
+
+The `TensorOperations` package is designed to provide powerful tools for performing tensor computations efficiently.
+In advanced use cases, it can be desirable to squeeze the last drops of performance out of the library, by experimenting with either different micro-optimized implementations of the same operation, or by altering the memory management system.
+Here, we detail how to access these functionalities.
+
+## Backends
+
+### Backend Selection
+
+`TensorOperations` supports multiple backends for tensor contractions, allowing users to choose different implementations based on their specific needs.
+While special care is taken to ensure good defaults, we also provide the flexibility to select a backend manually.
+This can be achieved in a variety of ways:
+
+1. **Global setting**: The default backend can be set globally on a per-type basis, as well as a per-function basis. This is achieved by hooking into the implementation of the default backend selection procedure. In particular, this procedure ends up calling [`select_backend`](@ref)`, which can be overloaded to return a different backend.
+
+2. **Local setting**: Alternatively, the backend can be set locally for a specific call to either [`@tensor`](@ref), [`ncon`](@ref) or the function-based interface. Both `@tensor` and `ncon` accept a keyword argument `backend`, which will locally override the default backend selection mechanism. The result is that the specified backend will be inserted as a final argument to all calls of the primitive tensor operations. This is also how this can be achieved in the function-based interface.
+
+```julia
+using TensorOperations
+mybackend = StridedNative()
+
+# inserting a backend into the @tensor macro
+@tensor backend = mybackend A[i,j] := B[i,k] * C[k,j]
+
+# inserting a backend into the ncon function
+D = ncon([A, B, C], [[1, 2], [2, 3], [3, 1]]; backend=mybackend)
+
+# inserting a backend into the function-based interface
+tensoradd(A, pA, conjA, B, pB, conjB, C, pC, conjC, α, β, mybackend)
+```
+
+### Available Backends
+
+`TensorOperations` provides some options for backends out-of-the box.
+In particular, the following backends are available:
+
+```@docs
+DefaultBackend
+BaseCopy
+BaseView
+StridedNative
+StridedBLAS
+cuTENSORBackend
+```
+
+Here, arrays that are strided are typically handled most efficiently by the `Strided.jl`-based backends.
+By default, the `StridedBLAS` backend is used for element types that support BLAS operations, as it seems that the performance gains from using BLAS outweigh the overhead of sometimes having to allocate intermediate permuted arrays.
+
+On the other hand, the `BaseCopy` and `BaseView` backends are used for arrays that are not strided.
+These are designed to be as general as possible, and as a result are not as performant as specific implementations.
+Nevertheless, they can be useful for debugging purposes or for working with custom tensor types that have limited support for methods outside of `Base`.
+
+Finally, we also provide a `cuTENSORBackend` for use with the `cuTENSOR.jl` library, which is a NVidia GPU-accelerated tensor contraction library.
+This backend is only available through a package extension for `cuTENSOR`.
+
+### Custom Backends
+
+Users can also define their own backends, to facilitate experimentation with new implementations.
+This can be done by defining a new type that is a subtype of `AbstractBackend`, and dispatching on this type in the implementation of the primitive tensor operations.
+In particular, the only required implemented methods are [`tensoradd!`](@ref), [`tensortrace!`](@ref), [`tensorcontract!`](@ref).
+
+## Allocators
+
+Evaluating complex tensor networks is typically done most efficiently by pairwise operations.
+As a result, this procedure often requires the allocation of many temporary arrays, which can affect performance for certain operations.
+To mitigate this, `TensorOperations` exposes an allocator system, which allows users to more finely control the allocation of both output tensors and temporary tensors.
+
+In particular, the allocator system is used in multiple ways:
+As mentioned before, it can be used to allocate and free the intermediate tensors that are required to evaluate a tensor network in a pairwise fashion.
+Additionally, it can also be used to allocate and free temporary objects that arise when reshaping and permuting input tensors, for example when making them compatible with BLAS instructions.
+
+### Allocator Selection
+
+The allocator system can only be accessed *locally*, by passing an allocator to the `@tensor` macro, the `ncon` function, or the function-based interface.
+
+```julia
+using TensorOperations
+myallocator = ManualAllocator()
+
+# inserting a backend into the @tensor macro
+@tensor allocator = myallocator A[i,j] := B[i,k] * C[k,j]
+
+# inserting an allocator into the ncon function
+D = ncon([A, B, C], [[1, 2], [2, 3], [3, 1]]; allocator=myallocator)
+
+# inserting a backend into the function-based interface
+tensoradd(A, pA, conjA, B, pB, conjB, C, pC, conjC, α, β, DefaultBackend(), myallocator)
+```
+
+Important to note here is that the backend system is prioritized over the allocator system.
+In particular, this means that the backend will be selected **first**, while only then the allocator should be inserted.
+
+### Available Allocators
+
+`TensorOperations` also provides some options for allocators out-of-the box.
+
+```@docs
+DefaultAllocator
+ManualAllocator
+```
+
+By default, the `DefaultAllocator` is used, which uses Julia's built-in memory management system.
+Optionally, it can be useful to use the `ManualAllocator`, as the manual memory management reduces the pressure on the garbage collector.
+In particular in multi-threaded applications, this can sometimes lead to a significant performance improvement.
+
+Finally, users can also opt to use the `Bumper.jl` system, which pre-allocates a slab of memory that can be re-used afterwards.
+This is available through a package extension for `Bumper`.
+Here, the `allocator` object is just the provided buffers, which are then used to store the intermediate tensors.
+
+```julia
+using TensorOperations, Bumper
+buf = Bumper.default_buffer()
+@no_escape buf
+    @tensor allocator = buf A[i,j] := B[i,k] * C[k,j]
+end
+```
+For convenience, the construction above is also provided in a specialized macro form which is fully equivalent:
+
+```@docs
+@butensor
+```
+
+### Custom Allocators
+
+Users can also define their own allocators, to facilitate experimentation with new implementations.
+Here, no restriction is made on the type of the allocator, and any object can be passed as an allocator.
+The required implementated methods are [`tensoralloc`](@ref) and [`tensorfree`](@ref).
+

--- a/docs/src/man/backends.md
+++ b/docs/src/man/backends.md
@@ -60,6 +60,8 @@ Users can also define their own backends, to facilitate experimentation with new
 This can be done by defining a new type that is a subtype of `AbstractBackend`, and dispatching on this type in the implementation of the primitive tensor operations.
 In particular, the only required implemented methods are [`tensoradd!`](@ref), [`tensortrace!`](@ref), [`tensorcontract!`](@ref).
 
+For example, [`TensorOperationsTBLIS`](https://github.com/lkdvos/TensorOperationsTBLIS.jl) is a wrapper that provides a backend for tensor contractions using the [TBLIS](https://github.com/devinamatthews/tblis) library.
+
 ## Allocators
 
 Evaluating complex tensor networks is typically done most efficiently by pairwise operations.

--- a/docs/src/man/backends.md
+++ b/docs/src/man/backends.md
@@ -27,7 +27,7 @@ mybackend = StridedNative()
 D = ncon([A, B, C], [[1, 2], [2, 3], [3, 1]]; backend=mybackend)
 
 # inserting a backend into the function-based interface
-tensoradd(A, pA, conjA, B, pB, conjB, C, pC, conjC, α, β, mybackend)
+tensoradd(A, pA, conjA, B, pB, conjB, α, β, mybackend)
 ```
 
 ### Available Backends
@@ -85,7 +85,7 @@ myallocator = ManualAllocator()
 D = ncon([A, B, C], [[1, 2], [2, 3], [3, 1]]; allocator=myallocator)
 
 # inserting a backend into the function-based interface
-tensoradd(A, pA, conjA, B, pB, conjB, C, pC, conjC, α, β, DefaultBackend(), myallocator)
+tensoradd(A, pA, conjA, B, pB, conjB, α, β, DefaultBackend(), myallocator)
 ```
 
 Important to note here is that the backend system is prioritized over the allocator system.

--- a/ext/TensorOperationsBumperExt.jl
+++ b/ext/TensorOperationsBumperExt.jl
@@ -6,7 +6,8 @@ using Bumper
 function TensorOperations.tensoralloc(::Type{A}, structure, ::Val{istemp},
                                       buf::Union{SlabBuffer,AllocBuffer}) where {A<:AbstractArray,
                                                                                  istemp}
-    if istemp
+    # TODO: remove the `ndims` check if this is fixed in Bumper / StrideArraysCore
+    if istemp & ndims(A) > 0
         return Bumper.alloc!(buf, eltype(A), structure...)
     else
         return TensorOperations.tensoralloc(A, structure, Val(istemp))

--- a/ext/TensorOperationsBumperExt.jl
+++ b/ext/TensorOperationsBumperExt.jl
@@ -32,21 +32,15 @@ function TensorOperations._butensor(src, ex...)
     res_sym = gensym("result")
 
     # TODO: there is no check for doubled tensor kwargs
-    return Base.remove_linenums!(quote
-                                     $buf_sym = $(Expr(:call,
-                                                       GlobalRef(Bumper, :default_buffer)))
-                                     $cp_sym = $(Expr(:call,
-                                                      GlobalRef(Bumper, :checkpoint_save),
-                                                      buf_sym))
-                                     $res_sym = $(Expr(:macrocall,
-                                                       GlobalRef(TensorOperations,
-                                                                 Symbol("@tensor")),
-                                                       src, :(allocator = $buf_sym),
-                                                       ex...))
-                                     $(Expr(:call, GlobalRef(Bumper, :checkpoint_restore!),
-                                            cp_sym))
-                                     $res_sym
-                                 end)
+    newex = quote
+        $buf_sym = $(Expr(:call, GlobalRef(Bumper, :default_buffer)))
+        $cp_sym = $(Expr(:call, GlobalRef(Bumper, :checkpoint_save), buf_sym))
+        $res_sym = $(Expr(:macrocall, GlobalRef(TensorOperations, Symbol("@tensor")),
+                          src, :(allocator = $buf_sym), ex...))
+        $(Expr(:call, GlobalRef(Bumper, :checkpoint_restore!), cp_sym))
+        $res_sym
+    end
+    return return Base.remove_linenums!(newex)
 end
 
 end

--- a/ext/TensorOperationsBumperExt.jl
+++ b/ext/TensorOperationsBumperExt.jl
@@ -1,0 +1,50 @@
+module TensorOperationsBumperExt
+
+using TensorOperations
+using Bumper
+
+function TensorOperations.tensoralloc(::Type{A}, structure, ::Val{istemp},
+                                      buf::Union{SlabBuffer,AllocBuffer}) where {A<:AbstractArray,
+                                                                                 istemp}
+    if istemp
+        return Bumper.alloc!(buf, eltype(A), structure...)
+    else
+        return TensorOperations.tensoralloc(A, structure, Val(istemp))
+    end
+end
+
+function TensorOperations.blas_contract!(C, A, pA, conjA, B, pB, conjB, pAB, α, β,
+                                         allocator::Union{SlabBuffer,AllocBuffer})
+    @no_escape allocator begin
+        C = @invoke TensorOperations.blas_contract!(C::Any, A::Any, pA::Any, conjA::Any,
+                                                    B::Any, pB::Any,
+                                                    conjB::Any, pAB::Any, α::Any, β::Any,
+                                                    allocator::Any)
+    end
+    return C
+end
+
+function TensorOperations._butensor(src, ex...)
+    buf_sym = gensym("buffer")
+    cp_sym = gensym("checkpoint")
+    res_sym = gensym("result")
+
+    # TODO: there is no check for doubled tensor kwargs
+    return Base.remove_linenums!(quote
+                                     $buf_sym = $(Expr(:call,
+                                                       GlobalRef(Bumper, :default_buffer)))
+                                     $cp_sym = $(Expr(:call,
+                                                      GlobalRef(Bumper, :checkpoint_save),
+                                                      buf_sym))
+                                     $res_sym = $(Expr(:macrocall,
+                                                       GlobalRef(TensorOperations,
+                                                                 Symbol("@tensor")),
+                                                       src, :(allocator = $buf_sym),
+                                                       ex...))
+                                     $(Expr(:call, GlobalRef(Bumper, :checkpoint_restore!),
+                                            cp_sym))
+                                     $res_sym
+                                 end)
+end
+
+end

--- a/ext/TensorOperationsBumperExt.jl
+++ b/ext/TensorOperationsBumperExt.jl
@@ -16,10 +16,12 @@ end
 function TensorOperations.blas_contract!(C, A, pA, conjA, B, pB, conjB, pAB, α, β,
                                          allocator::Union{SlabBuffer,AllocBuffer})
     @no_escape allocator begin
-        C = @invoke TensorOperations.blas_contract!(C::Any, A::Any, pA::Any, conjA::Any,
-                                                    B::Any, pB::Any,
-                                                    conjB::Any, pAB::Any, α::Any, β::Any,
-                                                    allocator::Any)
+        C = Base.@invoke TensorOperations.blas_contract!(C::Any, A::Any, pA::Any,
+                                                         conjA::Any,
+                                                         B::Any, pB::Any,
+                                                         conjB::Any, pAB::Any, α::Any,
+                                                         β::Any,
+                                                         allocator::Any)
     end
     return C
 end

--- a/ext/TensorOperationscuTENSORExt.jl
+++ b/ext/TensorOperationscuTENSORExt.jl
@@ -29,7 +29,11 @@ using CUDA.Adapt: adapt
 using Strided
 using TupleTools: TupleTools as TT
 
-StridedViewsCUDAExt = Base.get_extension(Strided.StridedViews, :StridedViewsCUDAExt)
+const StridedViewsCUDAExt = @static if isdefined(Base, :get_extension)
+    Base.get_extension(Strided.StridedViews, :StridedViewsCUDAExt)
+else
+    Strided.StridedViews.StridedViewsCUDAExt
+end
 isnothing(StridedViewsCUDAExt) && error("StridedViewsCUDAExt not found")
 
 #-------------------------------------------------------------------------------------------
@@ -37,11 +41,13 @@ isnothing(StridedViewsCUDAExt) && error("StridedViewsCUDAExt not found")
 #-------------------------------------------------------------------------------------------
 function TensorOperations._cutensor(src, ex...)
     # TODO: there is no check for doubled tensor kwargs
-    Expr(:macrocall, GlobalRef(TensorOperations, Symbol("@tensor")),
-         src,
-         Expr(:(=), :backend, Expr(:call, GlobalRef(TensorOperations, :cuTENSORBackend))),
-         Expr(:(=), :allocator, Expr(:call, GlobalRef(TensorOperations, :CUDAAllocator))),
-         ex...)
+    return Expr(:macrocall, GlobalRef(TensorOperations, Symbol("@tensor")),
+                src,
+                Expr(:(=), :backend,
+                     Expr(:call, GlobalRef(TensorOperations, :cuTENSORBackend))),
+                Expr(:(=), :allocator,
+                     Expr(:call, GlobalRef(TensorOperations, :CUDAAllocator))),
+                ex...)
 end
 
 #-------------------------------------------------------------------------------------------

--- a/ext/TensorOperationscuTENSORExt.jl
+++ b/ext/TensorOperationscuTENSORExt.jl
@@ -143,7 +143,7 @@ function CUDAAllocator()
 end
 
 function TO.tensoralloc_add(TC, A::AbstractArray, pA::Index2Tuple, conjA::Bool,
-                            istemp::Bool,
+                            istemp::Val,
                             allocator::CUDAAllocator)
     ttype = CuArray{TC,TO.numind(pA)}
     structure = TO.tensoradd_structure(A, pA, conjA)
@@ -154,7 +154,7 @@ function TO.tensoralloc_contract(TC,
                                  A::AbstractArray, pA::Index2Tuple, conjA::Bool,
                                  B::AbstractArray, pB::Index2Tuple, conjB::Bool,
                                  pAB::Index2Tuple,
-                                 istemp::Bool,
+                                 istemp::Val,
                                  allocator::CUDAAllocator)
     ttype = CuArray{TC,TO.numind(pAB)}
     structure = TO.tensorcontract_structure(A, pA, conjA, B, pB, conjB, pAB)
@@ -168,8 +168,9 @@ end
 
 # NOTE: the general implementation in the `DefaultAllocator` case works just fine, without
 # selecting an explicit memory model
-function TO.tensoralloc(::Type{CuArray{T,N}}, structure, istemp::Bool,
-                        allocator::CUDAAllocator{Mout,Min,Mtemp}) where {T,N,Mout,Min,Mtemp}
+function TO.tensoralloc(::Type{CuArray{T,N}}, structure, ::Val{istemp},
+                        allocator::CUDAAllocator{Mout,Min,Mtemp}) where {T,N,istemp,Mout,
+                                                                         Min,Mtemp}
     M = istemp ? Mtemp : Mout
     return CuArray{T,N,M}(undef, structure)
 end

--- a/ext/TensorOperationscuTENSORExt.jl
+++ b/ext/TensorOperationscuTENSORExt.jl
@@ -63,7 +63,7 @@ function TO.tensoradd!(C::AbstractArray,
     C_cuda, isview = _custrided(C, allocator)
     A_cuda, = _custrided(A, allocator)
     tensoradd!(C_cuda, A_cuda, pA, conjA, α, β, backend, allocator)
-    isview || copy!(C, C_cuda)
+    isview || copy!(C, C_cuda.parent)
     return C
 end
 function TO.tensorcontract!(C::AbstractArray,
@@ -77,7 +77,7 @@ function TO.tensorcontract!(C::AbstractArray,
     B_cuda, = _custrided(B, allocator)
     tensorcontract!(C_cuda, A_cuda, pA, conjA, B_cuda, pB, conjB, pAB, α, β, backend,
                     allocator)
-    isview || copy!(C, C_cuda)
+    isview || copy!(C, C_cuda.parent)
     return C
 end
 function TO.tensortrace!(C::AbstractArray,
@@ -87,7 +87,7 @@ function TO.tensortrace!(C::AbstractArray,
     C_cuda, isview = _custrided(C, allocator)
     A_cuda, = _custrided(A, allocator)
     tensortrace!(C_cuda, A_cuda, p, q, conjA, α, β, backend, allocator)
-    isview || copy!(C, C_cuda)
+    isview || copy!(C, C_cuda.parent)
     return C
 end
 

--- a/ext/TensorOperationscuTENSORExt.jl
+++ b/ext/TensorOperationscuTENSORExt.jl
@@ -33,6 +33,18 @@ StridedViewsCUDAExt = Base.get_extension(Strided.StridedViews, :StridedViewsCUDA
 isnothing(StridedViewsCUDAExt) && error("StridedViewsCUDAExt not found")
 
 #-------------------------------------------------------------------------------------------
+# @cutensor macro
+#-------------------------------------------------------------------------------------------
+function TensorOperations._cutensor(src, ex...)
+    # TODO: there is no check for doubled tensor kwargs
+    Expr(:macrocall, GlobalRef(TensorOperations, Symbol("@tensor")),
+         src,
+         Expr(:(=), :backend, Expr(:call, GlobalRef(TensorOperations, :cuTENSORBackend))),
+         Expr(:(=), :allocator, Expr(:call, GlobalRef(TensorOperations, :CUDAAllocator))),
+         ex...)
+end
+
+#-------------------------------------------------------------------------------------------
 # Backend selection and passing
 #-------------------------------------------------------------------------------------------
 const CuStridedView = StridedViewsCUDAExt.CuStridedView

--- a/src/TensorOperations.jl
+++ b/src/TensorOperations.jl
@@ -7,7 +7,7 @@ using LinearAlgebra
 using LinearAlgebra: mul!, BlasFloat
 using Strided
 using StridedViews: isstrided
-using PtrArrays, Bumper
+using PtrArrays
 using LRUCache
 
 using Base.Meta: isexpr

--- a/src/TensorOperations.jl
+++ b/src/TensorOperations.jl
@@ -7,6 +7,7 @@ using LinearAlgebra
 using LinearAlgebra: mul!, BlasFloat
 using Strided
 using StridedViews: isstrided
+using PtrArrays, Bumper
 using LRUCache
 
 using Base.Meta: isexpr

--- a/src/TensorOperations.jl
+++ b/src/TensorOperations.jl
@@ -16,7 +16,7 @@ using Base.Meta: isexpr
 #---------
 # export macro API
 export @tensor, @tensoropt, @tensoropt_verbose, @optimalcontractiontree, @notensor, @ncon
-export @cutensor
+export @cutensor, @butensor
 
 # export function based API
 export ncon

--- a/src/implementation/allocator.jl
+++ b/src/implementation/allocator.jl
@@ -176,15 +176,3 @@ function tensorfree!(C::PtrArray, ::ManualAllocator)
     free(C)
     return nothing
 end
-
-# ------------------------------------------------------------------------------------------
-# BumperAllocator implementation
-# ------------------------------------------------------------------------------------------
-function tensoralloc(::Type{A}, structure, ::Val{istemp},
-                     buf::Union{SlabBuffer,AllocBuffer}) where {A<:AbstractArray,istemp}
-    if istemp
-        return Bumper.alloc!(buf, eltype(A), structure...)
-    else
-        return tensoralloc(A, structure, Val(istemp))
-    end
-end

--- a/src/implementation/allocator.jl
+++ b/src/implementation/allocator.jl
@@ -60,7 +60,7 @@ Promote the scalar types of a tensor addition to a common type.
 promote_add(args...) = Base.promote_op(+, args...)
 
 """
-    tensoralloc_add(TC, A, pA, conjA, [istemp=false, allocator])
+    tensoralloc_add(TC, A, pA, conjA, [istemp=Val(false), allocator])
 
 Allocate a tensor `C` of scalar type `TC` that would be the result of
 
@@ -80,7 +80,7 @@ function tensoralloc_add(TC, A, pA::Index2Tuple, conjA::Bool, istemp::Val=Val(fa
 end
 
 """
-    tensoralloc_contract(TC, A, pA, conjA, B, pB, conjB, pAB, [istemp=false, allocator])
+    tensoralloc_contract(TC, A, pA, conjA, B, pB, conjB, pAB, [istemp=Val(false), allocator])
 
 Allocate a tensor `C` of scalar type `TC` that would be the result of
 

--- a/src/implementation/allocator.jl
+++ b/src/implementation/allocator.jl
@@ -168,7 +168,7 @@ function tensoralloc(::Type{A}, structure, ::Val{istemp},
     if istemp
         return malloc(eltype(A), structure...)
     else
-        return tensoralloc(A, structure, istemp)
+        return tensoralloc(A, structure, Val(istemp))
     end
 end
 
@@ -185,6 +185,6 @@ function tensoralloc(::Type{A}, structure, ::Val{istemp},
     if istemp
         return Bumper.alloc!(buf, eltype(A), structure...)
     else
-        return tensoralloc(A, structure, istemp)
+        return tensoralloc(A, structure, Val(istemp))
     end
 end

--- a/src/implementation/allocator.jl
+++ b/src/implementation/allocator.jl
@@ -129,8 +129,9 @@ function tensoradd_structure(A::AbstractArray, pA::Index2Tuple, conjA::Bool)
     return size.(Ref(A), linearize(pA))
 end
 
-function tensorcontract_type(TC, A::AbstractArray, pA, conjA,
-                             B::AbstractArray, pB, conjB, pAB)
+function tensorcontract_type(TC, A::AbstractArray, pA::Index2Tuple, conjA::Bool,
+                             B::AbstractArray, pB::Index2Tuple, conjB::Bool,
+                             pAB::Index2Tuple)
     T1 = tensoradd_type(TC, A, pAB, conjA)
     T2 = tensoradd_type(TC, B, pAB, conjB)
     if T1 == T2
@@ -140,8 +141,9 @@ function tensorcontract_type(TC, A::AbstractArray, pA, conjA,
     end
 end
 
-function tensorcontract_structure(A::AbstractArray, pA, conjA,
-                                  B::AbstractArray, pB, conjB, pAB)
+function tensorcontract_structure(A::AbstractArray, pA::Index2Tuple, conjA::Bool,
+                                  B::AbstractArray, pB::Index2Tuple, conjB::Bool,
+                                  pAB::Index2Tuple)
     return let lA = length(pA[1])
         map(n -> n <= lA ? size(A, pA[1][n]) : size(B, pB[2][n - lA]), linearize(pAB))
     end
@@ -156,9 +158,7 @@ function tensoralloc(ttype, structure, ::Val=Val(false), allocator=DefaultAlloca
     return C
 end
 
-function tensorfree!(C, allocator=DefaultAllocator())
-    return nothing
-end
+tensorfree!(C, allocator=DefaultAllocator()) = nothing
 
 # ------------------------------------------------------------------------------------------
 # ManualAllocator implementation

--- a/src/implementation/base.jl
+++ b/src/implementation/base.jl
@@ -36,7 +36,7 @@ function tensoradd!(C::AbstractArray,
 
     # can we assume that C is mutable?
     # is there more functionality in base that we can use?
-    Atemp = tensoralloc_add(eltype(A), A, pA, conjA, true, allocator)
+    Atemp = tensoralloc_add(eltype(A), A, pA, conjA, Val(true), allocator)
     Ã = permutedims!(Atemp, A, linearize(pA))
     if conjA
         if iszero(β)
@@ -100,7 +100,7 @@ function tensortrace!(C::AbstractArray,
     so = TupleTools.getindices(szA, linearize(p))
     st = prod(TupleTools.getindices(szA, q[1]))
     perm = (linearize(p)..., linearize(q)...)
-    Atemp = tensoralloc_add(eltype(A), A, (perm, ()), conjA, true, allocator)
+    Atemp = tensoralloc_add(eltype(A), A, (perm, ()), conjA, Val(true), allocator)
     Ã = reshape(permutedims!(Atemp, A, perm), (prod(so), st, st))
 
     if conjA
@@ -183,29 +183,29 @@ function tensorcontract!(C::AbstractArray,
     sc1 = prod(sc)
 
     AB = tensoralloc_contract(eltype(C), A, pA, conjA, B, pB, conjB,
-                              trivialpermutation(pAB), true, allocator)
+                              trivialpermutation(pAB), Val(true), allocator)
     ÃB̃ = reshape(AB, (soA1, soB1))
     if conjA && conjB
-        Atemp = tensoralloc_add(eltype(C), A, reverse(pA), conjA, true, allocator)
-        Btemp = tensoralloc_add(eltype(C), B, reverse(pB), conjB, true, allocator)
+        Atemp = tensoralloc_add(eltype(C), A, reverse(pA), conjA, Val(true), allocator)
+        Btemp = tensoralloc_add(eltype(C), B, reverse(pB), conjB, Val(true), allocator)
         Ã = reshape(permutedims!(Atemp, A, linearize(reverse(pA))), (sc1, soA1))
         B̃ = reshape(permutedims!(Btemp, B, linearize(reverse(pB))), (soB1, sc1))
         mul!(ÃB̃, adjoint(Ã), adjoint(B̃))
     elseif conjA
-        Atemp = tensoralloc_add(eltype(C), A, reverse(pA), conjA, true, allocator)
-        Btemp = tensoralloc_add(eltype(C), B, pB, conjB, true, allocator)
+        Atemp = tensoralloc_add(eltype(C), A, reverse(pA), conjA, Val(true), allocator)
+        Btemp = tensoralloc_add(eltype(C), B, pB, conjB, Val(true), allocator)
         Ã = reshape(permutedims!(Atemp, A, linearize(reverse(pA))), (sc1, soA1))
         B̃ = reshape(permutedims!(Btemp, B, linearize(pB)), (sc1, soB1))
         mul!(ÃB̃, adjoint(Ã), B̃)
     elseif conjB
-        Atemp = tensoralloc_add(eltype(C), A, pA, conjA, true, allocator)
-        Btemp = tensoralloc_add(eltype(C), B, reverse(pB), conjB, true, allocator)
+        Atemp = tensoralloc_add(eltype(C), A, pA, conjA, Val(true), allocator)
+        Btemp = tensoralloc_add(eltype(C), B, reverse(pB), conjB, Val(true), allocator)
         Ã = reshape(permutedims!(Atemp, A, linearize(pA)), (soA1, sc1))
         B̃ = reshape(permutedims!(Btemp, B, linearize(reverse(pB))), (soB1, sc1))
         mul!(ÃB̃, Ã, adjoint(B̃))
     else
-        Atemp = tensoralloc_add(eltype(C), A, pA, conjA, true, allocator)
-        Btemp = tensoralloc_add(eltype(C), B, pB, conjB, true, allocator)
+        Atemp = tensoralloc_add(eltype(C), A, pA, conjA, Val(true), allocator)
+        Btemp = tensoralloc_add(eltype(C), B, pB, conjB, Val(true), allocator)
         Ã = reshape(permutedims!(Atemp, A, linearize(pA)), (soA1, sc1))
         B̃ = reshape(permutedims!(Btemp, B, linearize(pB)), (sc1, soB1))
         mul!(ÃB̃, Ã, B̃)
@@ -213,7 +213,7 @@ function tensorcontract!(C::AbstractArray,
     if istrivialpermutation(linearize(pAB))
         pAB = AB
     else
-        pABtemp = tensoralloc_add(eltype(C), AB, pAB, false, true, allocator)
+        pABtemp = tensoralloc_add(eltype(C), AB, pAB, false, Val(true), allocator)
         pAB = permutedims!(pABtemp, AB, linearize(pAB))
     end
     if iszero(β)

--- a/src/implementation/base.jl
+++ b/src/implementation/base.jl
@@ -37,7 +37,7 @@ function tensoradd!(C::AbstractArray,
     # can we assume that C is mutable?
     # is there more functionality in base that we can use?
     Atemp = tensoralloc_add(eltype(A), A, pA, conjA, Val(true), allocator)
-    Ãtemp = permutedims!(Atemp, A, linearize(pA))
+    Atemp = permutedims!(Atemp, A, linearize(pA))
     if conjA
         if iszero(β)
             C .= α .* conj.(Atemp)

--- a/src/implementation/base.jl
+++ b/src/implementation/base.jl
@@ -37,18 +37,18 @@ function tensoradd!(C::AbstractArray,
     # can we assume that C is mutable?
     # is there more functionality in base that we can use?
     Atemp = tensoralloc_add(eltype(A), A, pA, conjA, Val(true), allocator)
-    Atemp = permutedims!(Atemp, A, linearize(pA))
+    Ã = permutedims!(Atemp, A, linearize(pA))
     if conjA
         if iszero(β)
-            C .= α .* conj.(Atemp)
+            C .= α .* conj.(Ã)
         else
-            C .= β .* C .+ α .* conj.(Atemp)
+            C .= β .* C .+ α .* conj.(Ã)
         end
     else
         if iszero(β)
-            C .= α .* Atemp
+            C .= α .* Ã
         else
-            C .= β .* C .+ α .* Atemp
+            C .= β .* C .+ α .* Ã
         end
     end
     tensorfree!(Atemp, allocator)
@@ -101,28 +101,28 @@ function tensortrace!(C::AbstractArray,
     so = TupleTools.getindices(szA, linearize(p))
     st = prod(TupleTools.getindices(szA, q[1]))
     perm = (linearize(p)..., linearize(q)...)
-    Atemp′ = tensoralloc_add(eltype(A), A, (perm, ()), conjA, Val(true), allocator)
-    Ãtemp = reshape(permutedims!(Atemp′, A, perm), (prod(so), st, st))
+    Atemp = tensoralloc_add(eltype(A), A, (perm, ()), conjA, Val(true), allocator)
+    Ã = reshape(permutedims!(Atemp, A, perm), (prod(so), st, st))
     if conjA
         if iszero(β)
-            C .= α .* conj.(reshape(view(Ãtemp, :, 1, 1), so))
+            C .= α .* conj.(reshape(view(Ã, :, 1, 1), so))
         else
-            C .= β .* C .+ α .* conj.(reshape(view(Ãtemp, :, 1, 1), so))
+            C .= β .* C .+ α .* conj.(reshape(view(Ã, :, 1, 1), so))
         end
         for i in 2:st
-            C .+= α .* conj.(reshape(view(Ãtemp, :, i, i), so))
+            C .+= α .* conj.(reshape(view(Ã, :, i, i), so))
         end
     else
         if iszero(β)
-            C .= α .* reshape(view(Ãtemp, :, 1, 1), so)
+            C .= α .* reshape(view(Ã, :, 1, 1), so)
         else
-            C .= β .* C .+ α .* reshape(view(Ãtemp, :, 1, 1), so)
+            C .= β .* C .+ α .* reshape(view(Ã, :, 1, 1), so)
         end
         for i in 2:st
-            C .+= α .* reshape(view(Ãtemp, :, i, i), so)
+            C .+= α .* reshape(view(Ã, :, i, i), so)
         end
     end
-    tensorfree!(Atemp′, allocator)
+    tensorfree!(Atemp, allocator)
     return C
 end
 
@@ -222,7 +222,7 @@ function tensorcontract!(C::AbstractArray,
     else
         C .= β .* C .+ α .* pAB
     end
-    pAB === AB || tensorfree!(pAB, allocator)
+    pAB === AB || tensorfree!(pABtemp, allocator)
     tensorfree!(AB, allocator)
     return C
 end

--- a/src/implementation/functions.jl
+++ b/src/implementation/functions.jl
@@ -65,7 +65,7 @@ end
 # ------------------------------------------------------------------------------------------
 """
     tensoradd([IC=IA], A, IA, [conjA], B, IB, [conjB], [α=1, [β=1]])
-    tensoradd(A, pA::Index2Tuple, conjA, B, pB::Index2Tuple, pB::Index2Tuple, conjB, α=1, β=1, [backend]) # expert mode
+    tensoradd(A, pA::Index2Tuple, conjA, B, pB::Index2Tuple, conjB, α=1, β=1, [backend]) # expert mode
 
 Return the result of adding arrays `A` and `B` where the iterables `IA` and `IB`
 denote how the array data should be permuted in order to be added. More specifically,

--- a/src/implementation/functions.jl
+++ b/src/implementation/functions.jl
@@ -1,12 +1,31 @@
 # methods/simple.jl
 #
 # Method-based access to tensor operations using simple definitions.
+
+# utility function
+function _kwargs2args(; kwargs...)
+    for k in keys(kwargs)
+        if !(k in (:backend, :allocator))
+            throw(ArgumentError("unknown keyword argument: $k"))
+        end
+    end
+    if haskey(kwargs, :backend) && haskey(kwargs, :allocator)
+        return (kwargs[:backend], kwargs[:allocator])
+    elseif haskey(kwargs, :allocator)
+        return (DefaultBackend(), kwargs[:allocator])
+    elseif haskey(kwargs, :backend)
+        return (kwargs[:backend],)
+    else
+        return ()
+    end
+end
+
 # ------------------------------------------------------------------------------------------
 # tensorcopy
 # ------------------------------------------------------------------------------------------
 """
-    tensorcopy([IC=IA], A, IA, [conjA=false, [α=1]])
-    tensorcopy(A, pA::Index2Tuple, conjA, α, [backend]) # expert mode
+    tensorcopy([IC=IA], A, IA, [conjA=false, [α=1]]; [backend=..., allocator=...])
+    tensorcopy(A, pA::Index2Tuple, conjA, α, [backend, allocator]) # expert mode
 
 Create a copy of `A`, where the dimensions of `A` are assigned indices from the
 iterable `IA` and the indices of the copy are contained in `IC`. Both iterables
@@ -16,20 +35,23 @@ The result of this method is equivalent to `α * permutedims(A, pA)` where `pA` 
 permutation such that `IC = IA[pA]`. The implementation of `tensorcopy` is however more
 efficient on average, especially if `Threads.nthreads() > 1`.
 
-Optionally, the flag `conjA` can be used to specify whether the input tensor should be
-conjugated (`true`) or not (`false`).
+The optional argument `conjA` can be used to specify whether the input tensor should be
+conjugated (`true`) or not (`false`), whereas `α` can be used to scale the result. It is
+also optional to specify a backend implementation to use, and an allocator to be used if
+temporary tensor objects are needed.
 
 See also [`tensorcopy!`](@ref).
 """
 function tensorcopy end
 
-function tensorcopy(IC::Labels, A, IA::Labels, conjA::Bool=false, α::Number=One())
+function tensorcopy(IC::Labels, A, IA::Labels, conjA::Bool=false, α::Number=One();
+                    kwargs...)
     pA = add_indices(IA, IC)
-    return tensorcopy(A, pA, conjA, α)
+    return tensorcopy(A, pA, conjA, α, _kwargs2args(; kwargs...)...)
 end
 # default `IC`
-function tensorcopy(A, IA::Labels, conjA::Bool=false, α::Number=One())
-    return tensorcopy(IA, A, IA, conjA, α)
+function tensorcopy(A, IA::Labels, conjA::Bool=false, α::Number=One(); kwargs...)
+    return tensorcopy(IA, A, IA, conjA, α; kwargs...)
 end
 # expert mode
 function tensorcopy(A, pA::Index2Tuple, conjA::Bool=false, α::Number=One(),
@@ -40,7 +62,7 @@ function tensorcopy(A, pA::Index2Tuple, conjA::Bool=false, α::Number=One(),
 end
 
 """
-    tensorcopy!(C, A, pA::Index2Tuple, conjA=false, α=1, [backend])
+    tensorcopy!(C, A, pA::Index2Tuple, conjA=false, α=1, [backend, allocator])
 
 Copy the contents of tensor `A` into `C`, where the dimensions `A` are permuted according to
 the permutation and repartition `pA`.
@@ -48,7 +70,7 @@ the permutation and repartition `pA`.
 The result of this method is equivalent to `α * permutedims!(C, A, pA)`.
 
 Optionally, the flag `conjA` can be used to specify whether the input tensor should be
-conjugated (`true`) or not (`false`).
+conjugated (`true`) or not (`false`). 
 
 !!! warning 
     The object `C` must not be aliased with `A`.
@@ -64,8 +86,8 @@ end
 # tensoradd
 # ------------------------------------------------------------------------------------------
 """
-    tensoradd([IC=IA], A, IA, [conjA], B, IB, [conjB], [α=1, [β=1]])
-    tensoradd(A, pA::Index2Tuple, conjA, B, pB::Index2Tuple, conjB, α=1, β=1, [backend]) # expert mode
+    tensoradd([IC=IA], A, IA, [conjA], B, IB, [conjB], [α=1, [β=1]]; [backend=..., allocator=...])
+    tensoradd(A, pA::Index2Tuple, conjA, B, pB::Index2Tuple, conjB, α=1, β=1, [backend, allocator]) # expert mode
 
 Return the result of adding arrays `A` and `B` where the iterables `IA` and `IB`
 denote how the array data should be permuted in order to be added. More specifically,
@@ -81,23 +103,26 @@ See also [`tensoradd!`](@ref).
 """
 function tensoradd end
 
-function tensoradd(IC::Labels, A, IA::Labels, conjA::Bool, B, IB::Labels,
-                   conjB::Bool, α::Number=One(), β::Number=One())
-    return tensoradd(A, add_indices(IA, IC), conjA, B, add_indices(IB, IC), conjB, α, β)
+function tensoradd(IC::Labels, A, IA::Labels, conjA::Bool, B, IB::Labels, conjB::Bool,
+                   α::Number=One(), β::Number=One(); kwargs...)
+    pA = add_indices(IA, IC)
+    pB = add_indices(IB, IC)
+    return tensoradd(A, pA, conjA, B, pB, conjB, α, β, _kwargs2args(; kwargs...)...)
 end
 # default `IC`
 function tensoradd(A, IA::Labels, conjA::Bool, B, IB::Labels, conjB::Bool,
-                   α::Number=One(), β::Number=One())
-    return tensoradd(IA, A, IA, conjA, B, IB, conjB, α, β)
+                   α::Number=One(), β::Number=One(); kwargs...)
+    return tensoradd(IA, A, IA, conjA, B, IB, conjB, α, β; kwargs...)
 end
 # default `conjA` and `conjB`
-function tensoradd(IC::Labels, A, IA::Labels, B, IB::Labels, α::Number=One(),
-                   β::Number=One())
+function tensoradd(IC::Labels, A, IA::Labels, B, IB::Labels,
+                   α::Number=One(), β::Number=One(); kwargs...)
     return tensoradd(IC, A, IA, false, B, IB, false, α, β)
 end
 # default `IC`, `conjA` and `conjB`
-function tensoradd(A, IA::Labels, B, IB::Labels, α::Number=One(), β::Number=One())
-    return tensoradd(IA, A, IA, B, IB, α, β)
+function tensoradd(A, IA::Labels, B, IB::Labels, α::Number=One(), β::Number=One();
+                   kwargs...)
+    return tensoradd(IA, A, IA, B, IB, α, β; kwargs...)
 end
 # expert mode
 function tensoradd(A, pA::Index2Tuple, conjA::Bool,
@@ -114,8 +139,8 @@ end
 # tensortrace
 # ------------------------------------------------------------------------------------------
 """
-    tensortrace([IC], A, IA, [conjA], [α=1])
-    tensortrace(A, p::Index2Tuple, q::Index2Tuple, conjA, α=1, [backend]) # expert mode
+    tensortrace([IC], A, IA, [conjA], [α=1]; [backend=..., allocator=...])
+    tensortrace(A, p::Index2Tuple, q::Index2Tuple, conjA, α=1, [backend, allocator]) # expert mode
 
 Trace or contract pairs of indices of tensor `A`, by assigning them identical indices in the
 iterable `IA`. The untraced indices, which are assigned a unique index, can be reordered
@@ -130,22 +155,21 @@ See also [`tensortrace!`](@ref).
 """
 function tensortrace end
 
+function tensortrace(IC::Labels, A, IA::Labels, conjA::Bool, α::Number=One(); kwargs...)
+    p, q = trace_indices(IA, IC)
+    return tensortrace(A, p, q, conjA, α, _kwargs2args(; kwargs...)...)
+end
 # default `IC`
-function tensortrace(A, IA::Labels, conjA::Bool, α::Number=One())
-    return tensortrace(unique2(IA), A, IA, conjA, α)
+function tensortrace(A, IA::Labels, conjA::Bool, α::Number=One(); kwargs...)
+    return tensortrace(unique2(IA), A, IA, conjA, α; kwargs...)
 end
 # default `conjA`
-function tensortrace(IC::Labels, A, IA::Labels, α::Number=One())
-    return tensortrace(IC, A, IA, false, α)
+function tensortrace(IC::Labels, A, IA::Labels, α::Number=One(); kwargs...)
+    return tensortrace(IC, A, IA, false, α; kwargs...)
 end
 # default `IC` and `conjA`
-function tensortrace(A, IA::Labels, α::Number=One())
-    return tensortrace(unique2(IA), A, IA, false, α)
-end
-# labels to indices
-function tensortrace(IC::Labels, A, IA::Labels, conjA::Bool, α::Number=One())
-    p, q = trace_indices(IA, IC)
-    return tensortrace(A, p, q, conjA, α)
+function tensortrace(A, IA::Labels, α::Number=One(); kwargs...)
+    return tensortrace(unique2(IA), A, IA, false, α; kwargs...)
 end
 # expert mode
 function tensortrace(A, p::Index2Tuple, q::Index2Tuple, conjA::Bool, α::Number=One(),
@@ -158,10 +182,9 @@ end
 # ------------------------------------------------------------------------------------------
 # tensorcontract
 # ------------------------------------------------------------------------------------------
-
 """
-    tensorcontract([IC], A, IA, [conjA], B, IB, [conjB], [α=1])
-    tensorcontract(A, pA::Index2Tuple, conjA, B, pB::Index2Tuple, conjB, pAB::Index2Tuple, α=1, [backend]) # expert mode
+    tensorcontract([IC], A, IA, [conjA], B, IB, [conjB], [α=1]; [backend=..., allocator=...])
+    tensorcontract(A, pA::Index2Tuple, conjA, B, pB::Index2Tuple, conjB, pAB::Index2Tuple, α=1, [backend, allocator]) # expert mode
 
 Contract indices of tensor `A` with corresponding indices in tensor `B` by assigning
 them identical labels in the iterables `IA` and `IB`. The indices of the resulting
@@ -180,22 +203,23 @@ See also [`tensorcontract!`](@ref).
 function tensorcontract end
 
 function tensorcontract(IC::Labels, A, IA::Labels, conjA::Bool, B, IB::Labels, conjB::Bool,
-                        α::Number=One())
+                        α::Number=One(); kwargs...)
     pA, pB, pAB = contract_indices(IA, IB, IC)
-    return tensorcontract(A, pA, conjA, B, pB, conjB, pAB, α)
+    return tensorcontract(A, pA, conjA, B, pB, conjB, pAB, α, _kwargs2args(; kwargs...)...)
 end
 # default `IC`
 function tensorcontract(A, IA::Labels, conjA::Bool, B, IB::Labels, conjB::Bool,
-                        α::Number=One())
-    return tensorcontract(symdiff(IA, IB), A, IA, conjA, B, IB, conjB, α)
+                        α::Number=One(); kwargs...)
+    return tensorcontract(symdiff(IA, IB), A, IA, conjA, B, IB, conjB, α; kwargs...)
 end
 # default `conjA` and `conjB`
-function tensorcontract(IC::Labels, A, IA::Labels, B, IB::Labels, α::Number=One())
-    return tensorcontract(IC, A, IA, false, B, IB, false, α)
+function tensorcontract(IC::Labels, A, IA::Labels, B, IB::Labels, α::Number=One();
+                        kwargs...)
+    return tensorcontract(IC, A, IA, false, B, IB, false, α; kwargs...)
 end
 # default `IC`, `conjA` and `conjB`
-function tensorcontract(A, IA::Labels, B, IB::Labels, α::Number=One())
-    return tensorcontract(symdiff(IA, IB), A, IA, false, B, IB, false, α)
+function tensorcontract(A, IA::Labels, B, IB::Labels, α::Number=One(); kwargs...)
+    return tensorcontract(symdiff(IA, IB), A, IA, false, B, IB, false, α; kwargs...)
 end
 # expert mode
 function tensorcontract(A, pA::Index2Tuple, conjA::Bool,
@@ -213,8 +237,8 @@ end
 # ------------------------------------------------------------------------------------------
 
 """
-    tensorproduct([IC], A, IA, [conjA], B, IB, [conjB], [α=1])
-    tensorproduct(A, pA::Index2Tuple, conjA, B, pB::Index2Tuple, conjB, pAB::Index2Tuple, α=1, [backend]) # expert mode
+    tensorproduct([IC], A, IA, [conjA], B, IB, [conjB], [α=1]; [backend=..., allocator=...])
+    tensorproduct(A, pA::Index2Tuple, conjA, B, pB::Index2Tuple, conjB, pAB::Index2Tuple, α=1, [backend, allocator]) # expert mode
 
 Compute the tensor product (outer product) of two tensors `A` and `B`, i.e. returns a new
 tensor `C` with `ndims(C) = ndims(A) + ndims(B)`. The indices of the output tensor are
@@ -231,22 +255,22 @@ See also [`tensorproduct!`](@ref) and [`tensorcontract`](@ref).
 function tensorproduct end
 
 function tensorproduct(IC::Labels, A, IA::Labels, conjA::Bool, B, IB::Labels, conjB::Bool,
-                       α::Number=One())
+                       α::Number=One(); kwargs...)
     pA, pB, pAB = contract_indices(IA, IB, IC)
-    return tensorproduct(A, pA, conjA, B, pB, conjB, pAB, α)
+    return tensorproduct(A, pA, conjA, B, pB, conjB, pAB, α, _kwargs2args(; kwargs...)...)
 end
 # default `IC`
 function tensorproduct(A, IA::Labels, conjA::Bool, B, IB::Labels, conjB::Bool,
-                       α::Number=One())
-    return tensorproduct(vcat(IA, IB), A, IA, conjA, B, IB, conjB, α)
+                       α::Number=One(); kwargs...)
+    return tensorproduct(vcat(IA, IB), A, IA, conjA, B, IB, conjB, α; kwargs...)
 end
 # default `conjA` and `conjB`
-function tensorproduct(IC::Labels, A, IA::Labels, B, IB::Labels, α::Number=One())
-    return tensorproduct(IC, A, IA, false, B, IB, false, α)
+function tensorproduct(IC::Labels, A, IA::Labels, B, IB::Labels, α::Number=One(); kwargs...)
+    return tensorproduct(IC, A, IA, false, B, IB, false, α; kwargs...)
 end
 # default `IC`, `conjA` and `conjB`
-function tensorproduct(A, IA::Labels, B, IB::Labels, α::Number=One())
-    return tensorproduct(vcat(IA, IB), A, IA, false, B, IB, false, α)
+function tensorproduct(A, IA::Labels, B, IB::Labels, α::Number=One(); kwargs...)
+    return tensorproduct(vcat(IA, IB), A, IA, false, B, IB, false, α; kwargs...)
 end
 # expert mode
 function tensorproduct(A, pA::Index2Tuple, conjA::Bool,
@@ -259,11 +283,14 @@ function tensorproduct(A, pA::Index2Tuple, conjA::Bool,
 end
 
 """
-    tensorproduct!(C, A, pA::Index2Tuple, conjA, B, pB::Index2Tuple, conjB, pAB::Index2Tuple, α=1, β=0)
+    tensorproduct!(C, A, pA::Index2Tuple, conjA, B, pB::Index2Tuple, conjB, pAB::Index2Tuple, α=1, β=0, [backend, allocator])
 
 Compute the tensor product (outer product) of two tensors `A` and `B`, i.e. a wrapper of
 [`tensorcontract!`](@ref) with no indices being contracted over. This method checks whether
-the indices indeed specify a tensor product instead of a genuine contraction.
+the indices indeed specify a tensor product instead of a genuine contraction.  Optionally 
+specify a backend implementation to use, and an allocator to be used if temporary tensor
+objects are needed.
+
 
 !!! warning 
     The object `C` must not be aliased with `A` or `B`.

--- a/src/implementation/functions.jl
+++ b/src/implementation/functions.jl
@@ -35,7 +35,7 @@ end
 function tensorcopy(A, pA::Index2Tuple, conjA::Bool=false, α::Number=One(),
                     backend=DefaultBackend(), allocator=DefaultAllocator())
     TC = promote_add(scalartype(A), scalartype(α))
-    C = tensoralloc_add(TC, A, pA, conjA)
+    C = tensoralloc_add(TC, A, pA, conjA, Val(false), allocator)
     return tensorcopy!(C, A, pA, conjA, α, backend, allocator)
 end
 
@@ -105,7 +105,7 @@ function tensoradd(A, pA::Index2Tuple, conjA::Bool,
                    α::Number=One(), β::Number=One(),
                    backend=DefaultBackend(), allocator=DefaultAllocator())
     TC = promote_add(scalartype(A), scalartype(B), scalartype(α), scalartype(β))
-    C = tensoralloc_add(TC, A, pA, conjA, false, allocator)
+    C = tensoralloc_add(TC, A, pA, conjA, Val(false), allocator)
     C = tensorcopy!(C, A, pA, conjA, α, backend, allocator)
     return tensoradd!(C, B, pB, conjB, β, One(), backend, allocator)
 end
@@ -151,7 +151,7 @@ end
 function tensortrace(A, p::Index2Tuple, q::Index2Tuple, conjA::Bool, α::Number=One(),
                      backend=DefaultBackend(), allocator=DefaultAllocator())
     TC = promote_contract(scalartype(A), scalartype(α))
-    C = tensoralloc_add(TC, A, p, conjA, false, allocator)
+    C = tensoralloc_add(TC, A, p, conjA, Val(false), allocator)
     return tensortrace!(C, A, p, q, conjA, α, Zero(), backend, allocator)
 end
 
@@ -203,7 +203,7 @@ function tensorcontract(A, pA::Index2Tuple, conjA::Bool,
                         pAB::Index2Tuple, α::Number=One(),
                         backend=DefaultBackend(), allocator=DefaultAllocator())
     TC = promote_contract(scalartype(A), scalartype(B), scalartype(α))
-    C = tensoralloc_contract(TC, A, pA, conjA, B, pB, conjB, pAB, false, allocator)
+    C = tensoralloc_contract(TC, A, pA, conjA, B, pB, conjB, pAB, Val(false), allocator)
     return tensorcontract!(C, A, pA, conjA, B, pB, conjB, pAB, α, Zero(), backend,
                            allocator)
 end

--- a/src/implementation/strided.jl
+++ b/src/implementation/strided.jl
@@ -234,6 +234,15 @@ function blas_contract!(C, A, pA, conjA, B, pB, conjB, pAB, α, β, allocator)
     flagB || tensorfree!(B_.parent, allocator)
     return C
 end
+function blas_contract!(C, A, pA, conjA, B, pB, conjB, pAB, α, β,
+                        allocator::Union{SlabBuffer,AllocBuffer})
+    @no_escape allocator begin
+        C = @invoke blas_contract!(C::Any, A::Any, pA::Any, conjA::Any, B::Any, pB::Any,
+                                   conjB::Any, pAB::Any, α::Any, β::Any,
+                                   allocator::Any)
+    end
+    return C
+end
 
 function _unsafe_blas_contract!(C::StridedView{T},
                                 A::StridedView{T}, pA,

--- a/src/implementation/strided.jl
+++ b/src/implementation/strided.jl
@@ -223,7 +223,7 @@ function blas_contract!(C, A, pA, conjA, B, pB, conjB, pAB, α, β, allocator)
         C_ = C
         _unsafe_blas_contract!(C_, A_, pA, B_, pB, ipAB, α, β)
     else
-        C_ = StridedView(TensorOperations.tensoralloc_add(TC, C, ipAB, false, true,
+        C_ = StridedView(TensorOperations.tensoralloc_add(TC, C, ipAB, false, Val(true),
                                                           allocator))
         _unsafe_blas_contract!(C_, A_, pA, B_, pB, trivialpermutation(ipAB),
                                one(TC), zero(TC))
@@ -257,7 +257,7 @@ end
 @inline function makeblascontractable(A, pA, TC, allocator)
     flagA = isblascontractable(A, pA) && eltype(A) == TC
     if !flagA
-        A_ = StridedView(TensorOperations.tensoralloc_add(TC, A, pA, false, true,
+        A_ = StridedView(TensorOperations.tensoralloc_add(TC, A, pA, false, Val(true),
                                                           allocator))
         A = tensoradd!(A_, A, pA, false, One(), Zero())
         pA = trivialpermutation(pA)

--- a/src/implementation/strided.jl
+++ b/src/implementation/strided.jl
@@ -234,15 +234,6 @@ function blas_contract!(C, A, pA, conjA, B, pB, conjB, pAB, α, β, allocator)
     flagB || tensorfree!(B_.parent, allocator)
     return C
 end
-function blas_contract!(C, A, pA, conjA, B, pB, conjB, pAB, α, β,
-                        allocator::Union{SlabBuffer,AllocBuffer})
-    @no_escape allocator begin
-        C = @invoke blas_contract!(C::Any, A::Any, pA::Any, conjA::Any, B::Any, pB::Any,
-                                   conjB::Any, pAB::Any, α::Any, β::Any,
-                                   allocator::Any)
-    end
-    return C
-end
 
 function _unsafe_blas_contract!(C::StridedView{T},
                                 A::StridedView{T}, pA,

--- a/src/implementation/strided.jl
+++ b/src/implementation/strided.jl
@@ -223,8 +223,7 @@ function blas_contract!(C, A, pA, conjA, B, pB, conjB, pAB, α, β, allocator)
         C_ = C
         _unsafe_blas_contract!(C_, A_, pA, B_, pB, ipAB, α, β)
     else
-        C_ = StridedView(TensorOperations.tensoralloc_add(TC, C, ipAB, false, Val(true),
-                                                          allocator))
+        C_ = StridedView(tensoralloc_add(TC, C, ipAB, false, Val(true), allocator))
         _unsafe_blas_contract!(C_, A_, pA, B_, pB, trivialpermutation(ipAB),
                                one(TC), zero(TC))
         tensoradd!(C, C_, pAB, false, α, β)
@@ -257,8 +256,7 @@ end
 @inline function makeblascontractable(A, pA, TC, allocator)
     flagA = isblascontractable(A, pA) && eltype(A) == TC
     if !flagA
-        A_ = StridedView(TensorOperations.tensoralloc_add(TC, A, pA, false, Val(true),
-                                                          allocator))
+        A_ = StridedView(tensoralloc_add(TC, A, pA, false, Val(true), allocator))
         A = tensoradd!(A_, A, pA, false, One(), Zero())
         pA = trivialpermutation(pA)
     end

--- a/src/indexnotation/instantiators.jl
+++ b/src/indexnotation/instantiators.jl
@@ -113,7 +113,7 @@ function instantiate_generaltensor(dst, β, ex::Expr, α, leftind::Vector{Any},
     end
     if alloc ∈ (NewTensor, TemporaryTensor)
         TC = gensym("T_" * string(dst))
-        istemporary = (alloc === TemporaryTensor)
+        istemporary = Val(alloc === TemporaryTensor)
         if scaltype === nothing
             TCval = α === One() ? instantiate_scalartype(src) :
                     instantiate_scalartype(Expr(:call, :*, α, src))
@@ -260,7 +260,7 @@ function instantiate_contraction(dst, β, ex::Expr, α, leftind::Vector{Any},
         else
             TCval = scaltype
         end
-        istemporary = alloc === TemporaryTensor
+        istemporary = Val(alloc === TemporaryTensor)
         initC = Expr(:block, Expr(:(=), TCsym, TCval),
                      :($dst = tensoralloc_contract($TCsym, $A, $pA, $conjA, $B, $pB,
                                                    $conjB, $pAB, $istemporary)))

--- a/src/indexnotation/tensormacros.jl
+++ b/src/indexnotation/tensormacros.jl
@@ -304,19 +304,14 @@ transfer it back. This macro is equivalent to
     This macro requires the cuTENSOR library to be installed and loaded. This can be
     achieved by running `using cuTENSOR` or `import cuTENSOR` before using the macro.
 """
-macro cutensor(ex::Expr)
-    haskey(Base.loaded_modules, Base.identify_package("cuTENSOR")) ||
-        throw(ArgumentError("cuTENSOR not loaded: add `using cuTENSOR` or `import cuTENSOR` before using `@cutensor`"))
-    parser = TensorParser()
-    push!(parser.postprocessors,
-          ex -> insertbackend(ex,
-                              Expr(:call, GlobalRef(TensorOperations, :cuTENSORBackend))))
-    push!(parser.postprocessors,
-          ex -> insertallocator(ex,
-                                Expr(:call, GlobalRef(TensorOperations, :CUDAAllocator))))
-    return esc(parser(ex))
+macro cutensor(ex...)
+    if length(methods(_cutensor)) == 0
+        throw(ArgumentError("cuTENSOR.jl not loaded: add `using cuTENSOR` or `import cuTENSOR` before using `@cutensor`"))
+    end
+    return esc(_cutensor(__source__, ex...))
 end
 
+function _cutensor end
 """
     @butensor tensor_expr
 
@@ -330,6 +325,9 @@ Bumper.jl.
     `using Bumper` or `import Bumper` before using the macro.
 """
 macro butensor(ex...)
+    if length(methods(_butensor)) == 0
+        throw(ArgumentError("Bumper.jl not loaded: add `using Bumper` or `import Bumper` before using `@butensor`"))
+    end
     return esc(_butensor(__source__, ex...))
 end
 

--- a/src/indexnotation/tensormacros.jl
+++ b/src/indexnotation/tensormacros.jl
@@ -324,18 +324,14 @@ Use Bumper.jl to handle allocation of temporary tensors. This macro will use the
 buffer and automatically reset it after the tensor expression has been evaluated. This macro
 is equivalent to `@no_escape @tensor tensor_expr` with all temporary allocations handled by
 Bumper.jl.
+
+!!! note
+    This macro requires Bumper.jl to be installed and loaded. This can be achieved by running
+    `using Bumper` or `import Bumper` before using the macro.
 """
 macro butensor(ex...)
-    buf_sym = gensym("buffer")
-    cp_sym = gensym("checkpoint")
-    res_sym = gensym("result")
-    return esc(quote
-                   $buf_sym = $(Expr(:call, GlobalRef(Bumper, :default_buffer)))
-                   $cp_sym = $(Expr(:call, GlobalRef(Bumper, :checkpoint_save), buf_sym))
-                   $res_sym = $(Expr(:macrocall,
-                                     GlobalRef(TensorOperations, Symbol("@tensor")),
-                                     __source__, :(allocator = $buf_sym), ex...))
-                   $(Expr(:call, GlobalRef(Bumper, :checkpoint_restore!), cp_sym))
-                   $res_sym
-               end)
+    return esc(_butensor(__source__, ex...))
 end
+
+# construction to move implementation to a package extension
+function _butensor end

--- a/test/butensor.jl
+++ b/test/butensor.jl
@@ -1,0 +1,68 @@
+@testset "@butensor dependency check" begin
+    @test_throws ArgumentError begin
+        ex = :(@butensor A[a, b, c, d] := B[a, b, c, d])
+        macroexpand(Main, ex)
+    end
+end
+
+using Bumper
+@testset "Bumper tests with eltype $T" for T in (Float32, ComplexF64)
+    D1, D2, D3 = 30, 40, 20
+    d1, d2 = 2, 3
+
+    A1 = randn(T, D1, d1, D2)
+    A2 = randn(T, D2, d2, D3)
+    ρₗ = randn(T, D1, D1)
+    ρᵣ = randn(T, D3, D3)
+    H = randn(T, d1, d2, d1, d2)
+
+    @tensor begin
+        HRAA1[a, s1, s2, c] := ρₗ[a, a'] * A1[a', t1, b] * A2[b, t2, c'] *
+                               ρᵣ[c', c] *
+                               H[s1, s2, t1, t2]
+    end
+
+    # butensor implementation
+    @butensor begin
+        HRAA2[a, s1, s2, c] := ρₗ[a, a'] * A1[a', t1, b] * A2[b, t2, c'] *
+                               ρᵣ[c', c] *
+                               H[s1, s2, t1, t2]
+    end
+    @test HRAA2 isa Array{T,4}
+    @test HRAA2 ≈ HRAA1
+
+    # manual equivalent
+    @no_escape @tensor allocator = default_buffer() begin
+        HRAA3[a, s1, s2, c] := ρₗ[a, a'] * A1[a', t1, b] * A2[b, t2, c'] *
+                               ρᵣ[c', c] *
+                               H[s1, s2, t1, t2]
+    end
+    @test HRAA3 isa Array{T,4}
+    @test HRAA3 ≈ HRAA1
+
+    # new buffer / completely manual
+    slabsize = typeof(default_buffer()).parameters[1] >> 1 # take slab size half as big
+    slabbuf = SlabBuffer{slabsize}()
+    begin
+        local cp = Bumper.checkpoint_save(slabbuf)
+        @tensor allocator = slabbuf begin
+            HRAA4[a, s1, s2, c] := ρₗ[a, a'] * A1[a', t1, b] * A2[b, t2, c'] *
+                                   ρᵣ[c', c] *
+                                   H[s1, s2, t1, t2]
+        end
+        bufferlength = slabsize * length(slabbuf.slabs)
+        Bumper.checkpoint_restore!(cp)
+    end
+    @test HRAA4 isa Array{T,4}
+    @test HRAA4 ≈ HRAA1
+
+    # allocbuffer
+    allocbuf = AllocBuffer(bufferlength)
+    @no_escape allocbuf @tensor allocator = allocbuf begin
+        HRAA5[a, s1, s2, c] := ρₗ[a, a'] * A1[a', t1, b] * A2[b, t2, c'] *
+                               ρᵣ[c', c] *
+                               H[s1, s2, t1, t2]
+    end
+    @test HRAA5 isa Array{T,4}
+    @test HRAA5 ≈ HRAA1
+end

--- a/test/butensor.jl
+++ b/test/butensor.jl
@@ -20,6 +20,8 @@ using Bumper
         HRAA1[a, s1, s2, c] := ρₗ[a, a'] * A1[a', t1, b] * A2[b, t2, c'] *
                                ρᵣ[c', c] *
                                H[s1, s2, t1, t2]
+        E1 = ρₗ[a', a] * A1[a, s, b] * A2[b, s', c] * ρᵣ[c, c'] * H[t, t', s, s'] *
+             conj(A1[a', t, b']) * conj(A2[b', t', c'])
     end
 
     # butensor implementation
@@ -27,18 +29,26 @@ using Bumper
         HRAA2[a, s1, s2, c] := ρₗ[a, a'] * A1[a', t1, b] * A2[b, t2, c'] *
                                ρᵣ[c', c] *
                                H[s1, s2, t1, t2]
+        E2 = ρₗ[a', a] * A1[a, s, b] * A2[b, s', c] * ρᵣ[c, c'] * H[t, t', s, s'] *
+             conj(A1[a', t, b']) * conj(A2[b', t', c'])
     end
     @test HRAA2 isa Array{T,4}
+    @test E2 isa T
     @test HRAA2 ≈ HRAA1
+    @test E2 ≈ E1
 
     # manual equivalent
     @no_escape @tensor allocator = default_buffer() begin
         HRAA3[a, s1, s2, c] := ρₗ[a, a'] * A1[a', t1, b] * A2[b, t2, c'] *
                                ρᵣ[c', c] *
                                H[s1, s2, t1, t2]
+        E3 = ρₗ[a', a] * A1[a, s, b] * A2[b, s', c] * ρᵣ[c, c'] * H[t, t', s, s'] *
+             conj(A1[a', t, b']) * conj(A2[b', t', c'])
     end
     @test HRAA3 isa Array{T,4}
+    @test E3 isa T
     @test HRAA3 ≈ HRAA1
+    @test E3 ≈ E1
 
     # new buffer / completely manual
     slabsize = typeof(default_buffer()).parameters[1] >> 1 # take slab size half as big
@@ -49,12 +59,16 @@ using Bumper
             HRAA4[a, s1, s2, c] := ρₗ[a, a'] * A1[a', t1, b] * A2[b, t2, c'] *
                                    ρᵣ[c', c] *
                                    H[s1, s2, t1, t2]
+            E4 = ρₗ[a', a] * A1[a, s, b] * A2[b, s', c] * ρᵣ[c, c'] * H[t, t', s, s'] *
+                 conj(A1[a', t, b']) * conj(A2[b', t', c'])
         end
         bufferlength = slabsize * length(slabbuf.slabs)
         Bumper.checkpoint_restore!(cp)
     end
     @test HRAA4 isa Array{T,4}
+    @test E4 isa T
     @test HRAA4 ≈ HRAA1
+    @test E4 ≈ E1
 
     # allocbuffer
     allocbuf = AllocBuffer(bufferlength)
@@ -62,7 +76,11 @@ using Bumper
         HRAA5[a, s1, s2, c] := ρₗ[a, a'] * A1[a', t1, b] * A2[b, t2, c'] *
                                ρᵣ[c', c] *
                                H[s1, s2, t1, t2]
+        E5 = ρₗ[a', a] * A1[a, s, b] * A2[b, s', c] * ρᵣ[c, c'] * H[t, t', s, s'] *
+             conj(A1[a', t, b']) * conj(A2[b', t', c'])
     end
     @test HRAA5 isa Array{T,4}
+    @test E5 isa T
     @test HRAA5 ≈ HRAA1
+    @test E5 ≈ E1
 end

--- a/test/cutensor.jl
+++ b/test/cutensor.jl
@@ -138,8 +138,8 @@ if cuTENSOR.has_cutensor()
 
             @tensor backend = cuTENSORBackend() allocator = CUDAAllocator() begin
                 HRAA3[a, s1, s2, c] := ρₗ[a, a'] * A1[a', t1, b] * A2[b, t2, c'] *
-                                        ρᵣ[c', c] *
-                                        H[s1, s2, t1, t2]
+                                       ρᵣ[c', c] *
+                                       H[s1, s2, t1, t2]
             end
             @test HRAA3 isa CuArray{T}
             @test collect(HRAA3) ≈ HRAA1

--- a/test/cutensor.jl
+++ b/test/cutensor.jl
@@ -1,4 +1,4 @@
-@testset "cuTENSOR dependency check" begin
+@testset "@cutensor dependency check" begin
     @test_throws ArgumentError begin
         ex = :(@cutensor A[a, b, c, d] := B[a, b, c, d])
         macroexpand(Main, ex)

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -9,7 +9,8 @@ backendlist = (BaseCopy(), BaseView(), StridedNative(), StridedBLAS())
         C1 = permutedims(A, p)
         C2 = @inferred tensorcopy((p...,), A, (1:4...,); backend=b)
         C3 = @inferred tensorcopy(A, (p, ()), false, 1, b)
-        @test C1 ≈ C2 ≈ C3
+        @test C1 ≈ C2
+        @test C2 == C3
         @test C1 ≈ ncon(Any[A], Any[[-2, -4, -1, -3]])
         @test_throws IndexError tensorcopy(1:4, A, 1:3)
         @test_throws IndexError tensorcopy(1:4, A, [1, 2, 2, 4])
@@ -22,7 +23,8 @@ backendlist = (BaseCopy(), BaseView(), StridedNative(), StridedBLAS())
         C1 = A + permutedims(B, p)
         C2 = @inferred tensoradd(A, p, B, (1:4...,); backend=b)
         C3 = @inferred tensoradd(A, ((1:4...,), ()), false, B, (p, ()), false, 1.0, 1.0, b)
-        @test C1 ≈ C2 ≈ C3
+        @test C1 ≈ C2
+        @test C2 == C3
         @test C1 ≈ A + ncon(Any[B], Any[[-2, -4, -1, -3]]; backend=b)
         @test_throws DimensionMismatch tensoradd(A, 1:4, B, 1:4)
     end
@@ -37,7 +39,8 @@ backendlist = (BaseCopy(), BaseView(), StridedNative(), StridedBLAS())
         end
         C2 = tensortrace(A, [:a, :b, :b]; backend=b)
         C3 = ncon(Any[A], Any[[-1, 1, 1]]; backend=b)
-        @test C1 ≈ C2 ≈ C3
+        @test C1 ≈ C2
+        @test C2 == C3
         A = randn(Float64, (3, 20, 5, 3, 20, 4, 5))
         C1 = zeros(4, 3, 3)
         for i1 in 1:4, i2 in 1:3, i3 in 1:3
@@ -48,7 +51,8 @@ backendlist = (BaseCopy(), BaseView(), StridedNative(), StridedBLAS())
         C2 = @inferred tensortrace((:e, :a, :d), A, (:a, :b, :c, :d, :b, :e, :c); backend=b)
         C3 = @inferred tensortrace(A, ((6, 1, 4), ()), ((2, 3), (5, 7)), false, 1.0, b)
         C4 = ncon(Any[A], Any[[-2, 1, 2, -3, 1, -1, 2]]; backend=b)
-        @test C1 ≈ C2 ≈ C3 ≈ C4
+        @test C1 ≈ C2
+        @test C2 == C3 == C4
     end
 
     @testset "tensorcontract" begin
@@ -69,7 +73,8 @@ backendlist = (BaseCopy(), BaseView(), StridedNative(), StridedBLAS())
         C5 = ncon(Any[A, B], Any[[-1, 1, 2, -4, -3], [2, -5, 1, -2]]; backend=b,
                   allocator=ManualAllocator())
 
-        @test C1 ≈ C2 ≈ C3 ≈ C4 ≈ C5
+        @test C1 ≈ C2
+        @test C2 == C3 == C4 == C5
         @test_throws IndexError tensorcontract(A, [:a, :b, :c, :d], B, [:c, :f, :b, :g])
         @test_throws IndexError tensorcontract(A, [:a, :b, :c, :a, :e], B, [:c, :f, :b, :g])
     end
@@ -99,7 +104,8 @@ backendlist = (BaseCopy(), BaseView(), StridedNative(), StridedBLAS())
                            ((2, 3, 1, 4), ()), 1.0, b)
         C4 = tensorproduct(A, ((1, 2), ()), false, B, ((), (1, 2)), false,
                            ((2, 3, 1, 4), ()), 1.0, b, ManualAllocator())
-        @test C1 ≈ C2 ≈ C3 ≈ C4
+        @test C1 ≈ C2
+        @test C2 == C3 == C4
     end
 end
 

--- a/test/methods.jl
+++ b/test/methods.jl
@@ -1,20 +1,15 @@
-using TensorOperations
-using Test
-using TensorOperations: IndexError
-using TensorOperations: BaseCopy, BaseView, StridedNative, StridedBLAS
+backendlist = (BaseCopy(), BaseView(), StridedNative(), StridedBLAS())
 
 # test simple methods
 #---------------------
-@testset "simple methods" begin
+@testset "simple methods with backend = $b" for b in backendlist
     @testset "tensorcopy" begin
         A = randn(Float64, (3, 5, 4, 6))
         p = (3, 1, 4, 2)
         C1 = permutedims(A, p)
-        C2 = @inferred tensorcopy((p...,), A, (1:4...,))
-        C3 = @inferred tensorcopy(A, (p, ()), false, 1, StridedNative())
-        C4 = @inferred tensorcopy(A, (p, ()), false, 1, BaseView())
-        C5 = @inferred tensorcopy(A, (p, ()), false, 1, BaseCopy())
-        @test C1 ≈ C2 ≈ C3 ≈ C4 ≈ C5
+        C2 = @inferred tensorcopy((p...,), A, (1:4...,); backend=b)
+        C3 = @inferred tensorcopy(A, (p, ()), false, 1, b)
+        @test C1 ≈ C2 ≈ C3
         @test C1 ≈ ncon(Any[A], Any[[-2, -4, -1, -3]])
         @test_throws IndexError tensorcopy(1:4, A, 1:3)
         @test_throws IndexError tensorcopy(1:4, A, [1, 2, 2, 4])
@@ -24,75 +19,57 @@ using TensorOperations: BaseCopy, BaseView, StridedNative, StridedBLAS
         A = randn(Float64, (3, 5, 4, 6))
         B = randn(Float64, (5, 6, 3, 4))
         p = (3, 1, 4, 2)
-        C1 = @inferred tensoradd(A, p, B, (1:4...,))
-        C2 = A + permutedims(B, p)
-        @test C1 ≈ C2
-        @test C1 ≈ A + ncon(Any[B], Any[[-2, -4, -1, -3]])
-        @test C1 ≈
-              @inferred tensoradd(A, ((1:4...,), ()), false, B, (p, ()), false, 1.0, 1.0,
-                                  StridedNative())
-        @test C1 ≈
-              @inferred tensoradd(A, ((1:4...,), ()), false, B, (p, ()), false, 1.0, 1.0,
-                                  BaseView())
-        @test C1 ≈
-              @inferred tensoradd(A, ((1:4...,), ()), false, B, (p, ()), false, 1.0, 1.0,
-                                  BaseCopy())
-
+        C1 = A + permutedims(B, p)
+        C2 = @inferred tensoradd(A, p, B, (1:4...,); backend=b)
+        C3 = @inferred tensoradd(A, ((1:4...,), ()), false, B, (p, ()), false, 1.0, 1.0, b)
+        @test C1 ≈ C2 ≈ C3
+        @test C1 ≈ A + ncon(Any[B], Any[[-2, -4, -1, -3]]; backend=b)
         @test_throws DimensionMismatch tensoradd(A, 1:4, B, 1:4)
     end
 
     @testset "tensortrace" begin
         A = randn(Float64, (50, 100, 100))
-        C1 = tensortrace(A, [:a, :b, :b])
-        C2 = zeros(50)
+        C1 = zeros(50)
         for i in 1:50
             for j in 1:100
-                C2[i] += A[i, j, j]
+                C1[i] += A[i, j, j]
             end
         end
-        @test C1 ≈ C2
-        @test C1 ≈ ncon(Any[A], Any[[-1, 1, 1]])
+        C2 = tensortrace(A, [:a, :b, :b]; backend=b)
+        C3 = ncon(Any[A], Any[[-1, 1, 1]]; backend=b)
+        @test C1 ≈ C2 ≈ C3
         A = randn(Float64, (3, 20, 5, 3, 20, 4, 5))
-        C1 = @inferred tensortrace((:e, :a, :d), A, (:a, :b, :c, :d, :b, :e, :c))
-        C2 = zeros(4, 3, 3)
+        C1 = zeros(4, 3, 3)
         for i1 in 1:4, i2 in 1:3, i3 in 1:3
             for j1 in 1:20, j2 in 1:5
-                C2[i1, i2, i3] += A[i2, j1, j2, i3, j1, i1, j2]
+                C1[i1, i2, i3] += A[i2, j1, j2, i3, j1, i1, j2]
             end
         end
-        @test C1 ≈ C2
-        C1 ≈ @inferred tensortrace(A, ((6, 1, 4), ()), ((2, 3), (5, 7)), false, 1.0,
-                                   StridedNative())
-        C1 ≈ @inferred tensortrace(A, ((6, 1, 4), ()), ((2, 3), (5, 7)), false, 1.0,
-                                   BaseView())
-        C1 ≈ @inferred tensortrace(A, ((6, 1, 4), ()), ((2, 3), (5, 7)), false, 1.0,
-                                   BaseCopy())
-        @test C1 ≈ ncon(Any[A], Any[[-2, 1, 2, -3, 1, -1, 2]])
+        C2 = @inferred tensortrace((:e, :a, :d), A, (:a, :b, :c, :d, :b, :e, :c); backend=b)
+        C3 = @inferred tensortrace(A, ((6, 1, 4), ()), ((2, 3), (5, 7)), false, 1.0, b)
+        C4 = ncon(Any[A], Any[[-2, 1, 2, -3, 1, -1, 2]]; backend=b)
+        @test C1 ≈ C2 ≈ C3 ≈ C4
     end
 
     @testset "tensorcontract" begin
         A = randn(Float64, (3, 20, 5, 3, 4))
         B = randn(Float64, (5, 6, 20, 3))
-        C1 = @inferred tensorcontract((:a, :g, :e, :d, :f),
-                                      A, (:a, :b, :c, :d, :e), B, (:c, :f, :b, :g))
-        C2 = zeros(3, 3, 4, 3, 6)
+        C1 = zeros(3, 3, 4, 3, 6)
         for a in 1:3, b in 1:20, c in 1:5, d in 1:3, e in 1:4, f in 1:6, g in 1:3
-            C2[a, g, e, d, f] += A[a, b, c, d, e] * B[c, f, b, g]
+            C1[a, g, e, d, f] += A[a, b, c, d, e] * B[c, f, b, g]
         end
-        @test C1 ≈ C2
-        @test C1 ≈
-              @inferred tensorcontract(A, ((1, 4, 5), (2, 3)), false, B, ((3, 1), (2, 4)),
-                                       false, ((1, 5, 3, 2, 4), ()), 1.0, StridedNative())
-        @test C1 ≈
-              @inferred tensorcontract(A, ((1, 4, 5), (2, 3)), false, B, ((3, 1), (2, 4)),
-                                       false, ((1, 5, 3, 2, 4), ()), 1.0, StridedBLAS())
-        @test C1 ≈
-              @inferred tensorcontract(A, ((1, 4, 5), (2, 3)), false, B, ((3, 1), (2, 4)),
-                                       false, ((1, 5, 3, 2, 4), ()), 1.0, BaseView())
-        @test C1 ≈
-              @inferred tensorcontract(A, ((1, 4, 5), (2, 3)), false, B, ((3, 1), (2, 4)),
-                                       false, ((1, 5, 3, 2, 4), ()), 1.0, BaseCopy())
-        @test C1 ≈ ncon(Any[A, B], Any[[-1, 1, 2, -4, -3], [2, -5, 1, -2]])
+        C2 = @inferred tensorcontract((:a, :g, :e, :d, :f),
+                                      A, (:a, :b, :c, :d, :e), B, (:c, :f, :b, :g);
+                                      backend=b)
+        C3 = @inferred tensorcontract(A, ((1, 4, 5), (2, 3)), false, B, ((3, 1), (2, 4)),
+                                      false, ((1, 5, 3, 2, 4), ()), 1.0, b)
+        C4 = @inferred tensorcontract(A, ((1, 4, 5), (2, 3)), false, B, ((3, 1), (2, 4)),
+                                      false, ((1, 5, 3, 2, 4), ()), 1.0, b,
+                                      ManualAllocator())
+        C5 = ncon(Any[A, B], Any[[-1, 1, 2, -4, -3], [2, -5, 1, -2]]; backend=b,
+                  allocator=ManualAllocator())
+
+        @test C1 ≈ C2 ≈ C3 ≈ C4 ≈ C5
         @test_throws IndexError tensorcontract(A, [:a, :b, :c, :d], B, [:c, :f, :b, :g])
         @test_throws IndexError tensorcontract(A, [:a, :b, :c, :a, :e], B, [:c, :f, :b, :g])
     end
@@ -100,10 +77,10 @@ using TensorOperations: BaseCopy, BaseView, StridedNative, StridedBLAS
     @testset "tensorproduct" begin
         A = randn(Float64, (5, 5, 5, 5))
         B = rand(ComplexF64, (5, 5, 5, 5))
-        C1 = reshape((@inferred tensorproduct((1, 2, 5, 6, 3, 4, 7, 8),
-                                              A, (1, 2, 3, 4), B, (5, 6, 7, 8))),
+        C1 = kron(reshape(B, (25, 25)), reshape(A, (25, 25)))
+        C2 = reshape((@inferred tensorproduct((1, 2, 5, 6, 3, 4, 7, 8),
+                                              A, (1, 2, 3, 4), B, (5, 6, 7, 8); backend=b)),
                      (5 * 5 * 5 * 5, 5 * 5 * 5 * 5))
-        C2 = kron(reshape(B, (25, 25)), reshape(A, (25, 25)))
         @test C1 ≈ C2
         @test_throws IndexError tensorproduct(A, [:a, :b, :c, :d],
                                               B, [:d, :e, :f, :g])
@@ -112,18 +89,17 @@ using TensorOperations: BaseCopy, BaseView, StridedNative, StridedBLAS
 
         A = rand(1, 2)
         B = rand(4, 5)
-        C1 = tensorcontract((-1, -2, -3, -4), A, (-3, -1), false, B, (-2, -4), false)
-        C2 = zeros(2, 4, 1, 5)
-        for i in axes(C2, 1), j in axes(C2, 2), k in axes(C2, 3), l in axes(C2, 4)
-            C2[i, j, k, l] = A[k, i] * B[j, l]
+        C1 = zeros(2, 4, 1, 5)
+        for i in axes(C1, 1), j in axes(C1, 2), k in axes(C1, 3), l in axes(C1, 4)
+            C1[i, j, k, l] = A[k, i] * B[j, l]
         end
-        @test C1 ≈ C2
-        @test C1 ≈ @inferred tensorproduct(A, ((1, 2), ()), false, B, ((), (1, 2)), false,
-                                           ((2, 3, 1, 4), ()), 1.0, StridedNative())
-        @test C1 ≈ @inferred tensorproduct(A, ((1, 2), ()), false, B, ((), (1, 2)), false,
-                                           ((2, 3, 1, 4), ()), 1.0, BaseView())
-        @test C1 ≈ @inferred tensorproduct(A, ((1, 2), ()), false, B, ((), (1, 2)), false,
-                                           ((2, 3, 1, 4), ()), 1.0, BaseCopy())
+        C2 = tensorcontract((-1, -2, -3, -4), A, (-3, -1), false, B, (-2, -4), false;
+                            backend=b)
+        C3 = tensorproduct(A, ((1, 2), ()), false, B, ((), (1, 2)), false,
+                           ((2, 3, 1, 4), ()), 1.0, b)
+        C4 = tensorproduct(A, ((1, 2), ()), false, B, ((), (1, 2)), false,
+                           ((2, 3, 1, 4), ()), 1.0, b, ManualAllocator())
+        @test C1 ≈ C2 ≈ C3 ≈ C4
     end
 end
 
@@ -131,7 +107,6 @@ end
 #-----------------------
 # test different versions of in-place methods,
 # with changing element type and with nontrivial strides
-backendlist = (StridedNative(), StridedBLAS(), BaseView(), BaseCopy())
 @testset "in-place methods with backend $b" for b in backendlist
     @testset "tensorcopy!" begin
         Abig = randn(Float64, (30, 30, 30, 30))
@@ -194,7 +169,9 @@ backendlist = (StridedNative(), StridedBLAS(), BaseView(), BaseCopy())
                                                     α, β, b)
     end
 
-    @testset "tensorcontract!" begin
+    @testset "tensorcontract! with allocator = $allocator" for allocator in
+                                                               (DefaultAllocator(),
+                                                                ManualAllocator())
         Abig = rand(Float64, (30, 30, 30, 30))
         A = view(Abig, 1 .+ 3 * (0:8), 2 .+ 2 * (0:14), 5 .+ 4 * (0:6), 7 .+ 2 * (0:8))
         Bbig = rand(ComplexF64, (50, 50, 50))
@@ -213,7 +190,7 @@ backendlist = (StridedNative(), StridedBLAS(), BaseView(), BaseCopy())
             end
         end
         tensorcontract!(C, A, ((4, 1), (2, 3)), false, B, ((3, 1), (2,)), true,
-                        ((1, 2, 3), ()), α, β, b)
+                        ((1, 2, 3), ()), α, β, b, allocator)
         @test C ≈ Ccopy
         @test_throws IndexError tensorcontract!(C,
                                                 A, ((4, 1), (2, 4)), false,

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -29,8 +29,14 @@ end
 
 # note: cuTENSOR should not be loaded before this point
 # as there is a test which requires it to be loaded after
-@testset "cuTENSOR" verbose = true begin
+@testset "cuTENSOR extension" verbose = true begin
     include("cutensor.jl")
+end
+
+# note: Bumper should not be loaded before this point
+# as there is a test which requires it to be loaded after
+@testset "Bumper extension" verbose = true begin
+    include("butensor.jl")
 end
 
 @testset "Polynomials" begin

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,9 +2,12 @@ using TensorOperations
 using LinearAlgebra
 using Test
 using Random
-using Aqua
-
 Random.seed!(1234567)
+
+using TensorOperations: IndexError
+using TensorOperations: BaseCopy, BaseView, StridedNative, StridedBLAS
+using TensorOperations: DefaultAllocator, ManualAllocator
+
 @testset "tensoropt" verbose = true begin
     include("tensoropt.jl")
 end


### PR DESCRIPTION
This PR attempts to add some additional allocator strategies to the toolbox, focused around dense arrays of isbits types.

I added some rudimentary support for [PtrArrays.jl](https://github.com/LilithHafner/PtrArrays.jl), which provides a manual way of implementing `malloc` and `free` for the temporaries. My first tests seem to indicate however that this does not improve the performance (even making it slightly worse in most cases). This probably requires more investigation, as it seems unlikely that this should be happening.

I also added support for [Bumper.jl](https://github.com/MasonProtter/Bumper.jl). Here, I use their buffer types as an allocator, which means that it is quite easy to manually make use of the bumper interface as follows:
```julia
buf = Bumper.default_buffer()
@no_escape buf begin
    @tensor allocator=buf tensorexpr...
end
```
Nevertheless, for further automation, I also added the convenience `@butensor` macro, which does exactly that.

---

Some implementation notes:

In order to make this work, the current way of dispatching with `StridedView`s and choosing between GPU and CPU definitely does not work. Both these options require a parent type of the StridedView which is not `Array` (but is `DenseArray`!), which would now be unsupported. I could add manual `select_backend` procedures for this, but I am a bit scared of the ambiguities, as I don't want to have to deal with the many combinations. This should probably be reconsidered.

In principle the current implementation of the Bumper methods could be part of a package extension, as it does not even require a definition of an `Allocator` type. Is this something we would like?

We should probably invest some time in a proper benchmark suite, as it is quite hard to gauge the effectiveness of these methods.