### PR TITLE
Fix typo in `tensoralloc` for Bumper allocator

### DIFF
--- a/ext/TensorOperationsBumperExt.jl
+++ b/ext/TensorOperationsBumperExt.jl
@@ -7,7 +7,7 @@ function TensorOperations.tensoralloc(::Type{A}, structure, ::Val{istemp},
                                       buf::Union{SlabBuffer,AllocBuffer}) where {A<:AbstractArray,
                                                                                  istemp}
     # TODO: remove the `ndims` check if this is fixed in Bumper / StrideArraysCore
-    if istemp & ndims(A) > 0
+    if istemp & (ndims(A) > 0)
         return Bumper.alloc!(buf, eltype(A), structure...)
     else
         return TensorOperations.tensoralloc(A, structure, Val(istemp))

--- a/ext/TensorOperationsBumperExt.jl
+++ b/ext/TensorOperationsBumperExt.jl
@@ -7,7 +7,7 @@ function TensorOperations.tensoralloc(::Type{A}, structure, ::Val{istemp},
                                       buf::Union{SlabBuffer,AllocBuffer}) where {A<:AbstractArray,
                                                                                  istemp}
     # TODO: remove the `ndims` check if this is fixed in Bumper / StrideArraysCore
-    if istemp & (ndims(A) > 0)
+    if istemp && ndims(A) > 0
         return Bumper.alloc!(buf, eltype(A), structure...)
     else
         return TensorOperations.tensoralloc(A, structure, Val(istemp))


### PR DESCRIPTION
Fixes what I think is a typo in the Bumper allocator. I assume this was supposed to be an `ndims` check to flag zero-dimensional arrays, but I think there were some parentheses missing which made it so that temporary arrays of rank<4 were never actually allocated in the buffer.

Or I'm missing something, but the patch seems to fix leaking allocations on my end and the tests still pass. @lkdvos 