### PR TITLE
Version 5.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "TensorOperations"
 uuid = "6aa20fa7-93e2-5fca-9bc0-fbd0db3c71a2"
 authors = ["Lukas Devos <lukas.devos@ugent.be>", "Maarten Van Damme <maartenvd1994@gmail.com>", "Jutho Haegeman <jutho.haegeman@ugent.be>"]
-version = "5.0.2"
+version = "5.1.0"
 
 [deps]
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"

--- a/ext/TensorOperationsBumperExt.jl
+++ b/ext/TensorOperationsBumperExt.jl
@@ -14,15 +14,11 @@ function TensorOperations.tensoralloc(::Type{A}, structure, ::Val{istemp},
     end
 end
 
-function TensorOperations.blas_contract!(C, A, pA, conjA, B, pB, conjB, pAB, α, β,
-                                         allocator::Union{SlabBuffer,AllocBuffer})
+function TensorOperations.blas_contract!(C, A, pA, B, pB, pAB, α, β,
+                                         backend, allocator::Union{SlabBuffer,AllocBuffer})
     @no_escape allocator begin
-        C = Base.@invoke TensorOperations.blas_contract!(C::Any, A::Any, pA::Any,
-                                                         conjA::Any,
-                                                         B::Any, pB::Any,
-                                                         conjB::Any, pAB::Any, α::Any,
-                                                         β::Any,
-                                                         allocator::Any)
+        C = Base.@invoke TensorOperations.blas_contract!(C, A, pA, B, pB, pAB, α, β,
+                                                         backend, allocator::Any)
     end
     return C
 end

--- a/ext/TensorOperationsChainRulesCoreExt.jl
+++ b/ext/TensorOperationsChainRulesCoreExt.jl
@@ -46,27 +46,34 @@ end
 
 # The current `rrule` design makes sure that the implementation for custom types does
 # not need to support the backend or allocator arguments
+# function ChainRulesCore.rrule(::typeof(TensorOperations.tensoradd!),
+#                               C,
+#                               A, pA::Index2Tuple, conjA::Bool,
+#                               α::Number, β::Number,
+#                               backend, allocator)
+#     val, pb = _rrule_tensoradd!(C, A, pA, conjA, α, β, (backend, allocator))
+#     return val, ΔC -> (pb(ΔC)..., NoTangent(), NoTangent())
+# end
+# function ChainRulesCore.rrule(::typeof(TensorOperations.tensoradd!),
+#                               C,
+#                               A, pA::Index2Tuple, conjA::Bool,
+#                               α::Number, β::Number,
+#                               backend)
+#     val, pb = _rrule_tensoradd!(C, A, pA, conjA, α, β, (backend,))
+#     return val, ΔC -> (pb(ΔC)..., NoTangent())
+# end
+# function ChainRulesCore.rrule(::typeof(TensorOperations.tensoradd!),
+#                               C,
+#                               A, pA::Index2Tuple, conjA::Bool,
+#                               α::Number, β::Number)
+#     return _rrule_tensoradd!(C, A, pA, conjA, α, β, ())
+# end
 function ChainRulesCore.rrule(::typeof(TensorOperations.tensoradd!),
                               C,
                               A, pA::Index2Tuple, conjA::Bool,
                               α::Number, β::Number,
-                              backend, allocator)
-    val, pb = _rrule_tensoradd!(C, A, pA, conjA, α, β, (backend, allocator))
-    return val, ΔC -> (pb(ΔC)..., NoTangent(), NoTangent())
-end
-function ChainRulesCore.rrule(::typeof(TensorOperations.tensoradd!),
-                              C,
-                              A, pA::Index2Tuple, conjA::Bool,
-                              α::Number, β::Number,
-                              backend)
-    val, pb = _rrule_tensoradd!(C, A, pA, conjA, α, β, (backend,))
-    return val, ΔC -> (pb(ΔC)..., NoTangent())
-end
-function ChainRulesCore.rrule(::typeof(TensorOperations.tensoradd!),
-                              C,
-                              A, pA::Index2Tuple, conjA::Bool,
-                              α::Number, β::Number)
-    return _rrule_tensoradd!(C, A, pA, conjA, α, β, ())
+                              ba...)
+    return _rrule_tensoradd!(C, A, pA, conjA, α, β, ba)
 end
 function _rrule_tensoradd!(C, A, pA, conjA, α, β, ba)
     C′ = tensoradd!(copy(C), A, pA, conjA, α, β, ba...)
@@ -98,40 +105,50 @@ function _rrule_tensoradd!(C, A, pA, conjA, α, β, ba)
                                               ((), ()), One(), ba...))
             return projectβ(_dβ)
         end
-        return NoTangent(), dC, dA, NoTangent(), NoTangent(), dα, dβ
+        dba = map(_ -> NoTangent(), ba)
+        return NoTangent(), dC, dA, NoTangent(), NoTangent(), dα, dβ, dba...
     end
 
     return C′, pullback
 end
 
+# function ChainRulesCore.rrule(::typeof(TensorOperations.tensorcontract!),
+#                               C,
+#                               A, pA::Index2Tuple, conjA::Bool,
+#                               B, pB::Index2Tuple, conjB::Bool,
+#                               pAB::Index2Tuple,
+#                               α::Number, β::Number,
+#                               backend, allocator)
+#     val, pb = _rrule_tensorcontract!(C, A, pA, conjA, B, pB, conjB, pAB, α, β,
+#                                      (backend, allocator))
+#     return val, ΔC -> (pb(ΔC)..., NoTangent(), NoTangent())
+# end
+# function ChainRulesCore.rrule(::typeof(TensorOperations.tensorcontract!),
+#                               C,
+#                               A, pA::Index2Tuple, conjA::Bool,
+#                               B, pB::Index2Tuple, conjB::Bool,
+#                               pAB::Index2Tuple,
+#                               α::Number, β::Number,
+#                               backend)
+#     val, pb = _rrule_tensorcontract!(C, A, pA, conjA, B, pB, conjB, pAB, α, β, (backend,))
+#     return val, ΔC -> (pb(ΔC)..., NoTangent())
+# end
+# function ChainRulesCore.rrule(::typeof(TensorOperations.tensorcontract!),
+#                               C,
+#                               A, pA::Index2Tuple, conjA::Bool,
+#                               B, pB::Index2Tuple, conjB::Bool,
+#                               pAB::Index2Tuple,
+#                               α::Number, β::Number)
+#     return _rrule_tensorcontract!(C, A, pA, conjA, B, pB, conjB, pAB, α, β, ())
+# end
 function ChainRulesCore.rrule(::typeof(TensorOperations.tensorcontract!),
                               C,
                               A, pA::Index2Tuple, conjA::Bool,
                               B, pB::Index2Tuple, conjB::Bool,
                               pAB::Index2Tuple,
                               α::Number, β::Number,
-                              backend, allocator)
-    val, pb = _rrule_tensorcontract!(C, A, pA, conjA, B, pB, conjB, pAB, α, β,
-                                     (backend, allocator))
-    return val, ΔC -> (pb(ΔC)..., NoTangent(), NoTangent())
-end
-function ChainRulesCore.rrule(::typeof(TensorOperations.tensorcontract!),
-                              C,
-                              A, pA::Index2Tuple, conjA::Bool,
-                              B, pB::Index2Tuple, conjB::Bool,
-                              pAB::Index2Tuple,
-                              α::Number, β::Number,
-                              backend)
-    val, pb = _rrule_tensorcontract!(C, A, pA, conjA, B, pB, conjB, pAB, α, β, (backend,))
-    return val, ΔC -> (pb(ΔC)..., NoTangent())
-end
-function ChainRulesCore.rrule(::typeof(TensorOperations.tensorcontract!),
-                              C,
-                              A, pA::Index2Tuple, conjA::Bool,
-                              B, pB::Index2Tuple, conjB::Bool,
-                              pAB::Index2Tuple,
-                              α::Number, β::Number)
-    return _rrule_tensorcontract!(C, A, pA, conjA, B, pB, conjB, pAB, α, β, ())
+                              ba...)
+    return _rrule_tensorcontract!(C, A, pA, conjA, B, pB, conjB, pAB, α, β, ba)
 end
 function _rrule_tensorcontract!(C, A, pA, conjA, B, pB, conjB, pAB, α, β, ba)
     C′ = tensorcontract!(copy(C), A, pA, conjA, B, pB, conjB, pAB, α, β, ba...)
@@ -187,32 +204,39 @@ function _rrule_tensorcontract!(C, A, pA, conjA, B, pB, conjB, pAB, α, β, ba)
                                               ((), ()), One(), ba...))
             return projectβ(_dβ)
         end
+        dba = map(_ -> NoTangent(), ba)
         return NoTangent(), dC,
                dA, NoTangent(), NoTangent(), dB, NoTangent(), NoTangent(),
-               NoTangent(), dα, dβ
+               NoTangent(), dα, dβ, dba...
     end
 
     return C′, pullback
 end
 
+# function ChainRulesCore.rrule(::typeof(tensortrace!), C,
+#                               A, p::Index2Tuple, q::Index2Tuple, conjA::Bool,
+#                               α::Number, β::Number,
+#                               backend, allocator)
+#     val, pb = _rrule_tensortrace!(C, A, p, q, conjA, α, β, (backend, allocator))
+#     return val, ΔC -> (pb(ΔC)..., NoTangent(), NoTangent())
+# end
+# function ChainRulesCore.rrule(::typeof(tensortrace!), C,
+#                               A, p::Index2Tuple, q::Index2Tuple, conjA::Bool,
+#                               α::Number, β::Number,
+#                               backend)
+#     val, pb = _rrule_tensortrace!(C, A, p, q, conjA, α, β, (backend,))
+#     return val, ΔC -> (pb(ΔC)..., NoTangent())
+# end
+# function ChainRulesCore.rrule(::typeof(tensortrace!), C,
+#                               A, p::Index2Tuple, q::Index2Tuple, conjA::Bool,
+#                               α::Number, β::Number)
+#     return _rrule_tensortrace!(C, A, p, q, conjA, α, β, ())
+# end
 function ChainRulesCore.rrule(::typeof(tensortrace!), C,
                               A, p::Index2Tuple, q::Index2Tuple, conjA::Bool,
                               α::Number, β::Number,
-                              backend, allocator)
-    val, pb = _rrule_tensortrace!(C, A, p, q, conjA, α, β, (backend, allocator))
-    return val, ΔC -> (pb(ΔC)..., NoTangent(), NoTangent())
-end
-function ChainRulesCore.rrule(::typeof(tensortrace!), C,
-                              A, p::Index2Tuple, q::Index2Tuple, conjA::Bool,
-                              α::Number, β::Number,
-                              backend)
-    val, pb = _rrule_tensortrace!(C, A, p, q, conjA, α, β, (backend,))
-    return val, ΔC -> (pb(ΔC)..., NoTangent())
-end
-function ChainRulesCore.rrule(::typeof(tensortrace!), C,
-                              A, p::Index2Tuple, q::Index2Tuple, conjA::Bool,
-                              α::Number, β::Number)
-    return _rrule_tensortrace!(C, A, p, q, conjA, α, β, ())
+                              ba...)
+    return _rrule_tensortrace!(C, A, p, q, conjA, α, β, ba)
 end
 function _rrule_tensortrace!(C, A, p, q, conjA, α, β, ba)
     C′ = tensortrace!(copy(C), A, p, q, conjA, α, β, ba...)
@@ -253,7 +277,8 @@ function _rrule_tensortrace!(C, A, p, q, conjA, α, β, ba)
                                               ((), ()), One(), ba...))
             return projectβ(_dβ)
         end
-        return NoTangent(), dC, dA, NoTangent(), NoTangent(), NoTangent(), dα, dβ
+        dba = map(_ -> NoTangent(), ba)
+        return NoTangent(), dC, dA, NoTangent(), NoTangent(), NoTangent(), dα, dβ, dba...
     end
 
     return C′, pullback

--- a/ext/TensorOperationscuTENSORExt.jl
+++ b/ext/TensorOperationscuTENSORExt.jl
@@ -29,12 +29,16 @@ using CUDA.Adapt: adapt
 using Strided
 using TupleTools: TupleTools as TT
 
-const StridedViewsCUDAExt = @static if isdefined(Base, :get_extension)
-    Base.get_extension(Strided.StridedViews, :StridedViewsCUDAExt)
-else
-    Strided.StridedViews.StridedViewsCUDAExt
-end
-isnothing(StridedViewsCUDAExt) && error("StridedViewsCUDAExt not found")
+# Disallowed paradigm from Julia 1.11.1 onwards:
+# const StridedViewsCUDAExt = @static if isdefined(Base, :get_extension)
+#     Base.get_extension(Strided.StridedViews, :StridedViewsCUDAExt)
+# else
+#     Strided.StridedViews.StridedViewsCUDAExt
+# end
+# isnothing(StridedViewsCUDAExt) && error("StridedViewsCUDAExt not found")
+
+# Literal copy of the StridedViewsCUDAExt module
+const CuStridedView{T,N,A<:CuArray{T}} = StridedView{T,N,A}
 
 #-------------------------------------------------------------------------------------------
 # @cutensor macro
@@ -53,8 +57,6 @@ end
 #-------------------------------------------------------------------------------------------
 # Backend selection and passing
 #-------------------------------------------------------------------------------------------
-const CuStridedView = StridedViewsCUDAExt.CuStridedView
-
 # A Base wrapper over `CuArray` will first pass via the `select_backend` methods for 
 # `AbstractArray` and be converted into a `StridedView` if it satisfies `isstrided`. Hence,
 # we only need to capture `CuStridedView` here.


### PR DESCRIPTION
This contains two commits, which should not be squashed.
1) this changes the strided implementation so as to always specialise, getting rid of small allocations and some overhead for small permutations
2) this abolishes the `get_extension` trick in the extensions which started to break on Julia 1.11.1, and simplifies the `rrule`s for the tensor operations so that also other packages (i.e. TensorKit) should not rely on that same broken trick to overload the `rrule`s

Along the way, it also fixes the `blas_contract` overload in the bumper extension so that it actually gets used.
