### PR TITLE
Clean up cuTENSOR plan memory

### DIFF
--- a/ext/TensorOperationscuTENSORExt.jl
+++ b/ext/TensorOperationscuTENSORExt.jl
@@ -312,7 +312,10 @@ function plan_trace(@nospecialize(A::AbstractArray), Ainds::ModeType,
     plan_pref = Ref{cutensorPlanPreference_t}()
     cutensorCreatePlanPreference(handle(), plan_pref, algo, jit)
 
-    return CuTensorPlan(desc[], plan_pref[]; workspacePref=workspace)
+    plan = CuTensorPlan(desc[], plan_pref[]; workspacePref=workspace)
+    cuTENSOR.cutensorDestroyOperationDescriptor(desc[])
+    cuTENSOR.cutensorDestroyPlanPreference(plan_pref[])
+    return plan
 end
 
 end


### PR DESCRIPTION
Improve memory management by ensuring proper destruction of operation descriptors and plan preferences in the cuTENSOR plan function.

This is the equivalent of https://github.com/JuliaGPU/CUDA.jl/pull/2794/files

Fixes #211