### PR TITLE
Add more descriptive errors to `ncon`

### DIFF
--- a/src/implementation/ncon.jl
+++ b/src/implementation/ncon.jl
@@ -28,7 +28,7 @@ function ncon(
     )
     length(tensors) == length(network) == length(conjlist) ||
         throw(ArgumentError("number of tensors and of index lists should be the same"))
-    isnconstyle(network) || throw(ArgumentError(_nconstyle_error(network)))
+    nconstylecheck(network) # asserts that the network is in ncon style
     output′ = nconoutput(network, output)
 
     if length(tensors) == 1

--- a/src/indexnotation/ncontree.jl
+++ b/src/indexnotation/ncontree.jl
@@ -1,8 +1,8 @@
-const ISNCONSTYLE = "Valid ncon style network"
+const NCONSTYLE = "Valid ncon style network"
 
 # check if a list of indices specifies a tensor contraction in ncon style
 function isnconstyle(network)
-    return _nconstyle_error(network) == ISNCONSTYLE
+    return _nconstyle_error(network) == NCONSTYLE
 end
 
 function _nconstyle_error(network)
@@ -25,7 +25,13 @@ function _nconstyle_error(network)
             return "Index 0 is not allowed in the network"
         end
     end
-    return ISNCONSTYLE
+    return NCONSTYLE
+end
+
+function nconstylecheck(network)
+    err = _nconstyle_error(network)
+    err === NCONSTYLE || throw(ArgumentError(err))
+    return nothing
 end
 
 function ncontree(network)


### PR DESCRIPTION
The `invalid NCON network` error did not provide the user with information on why the network did not comply with the ncon style, while this information was available during the checking procedure.

This PR provides the user more information on why their network did not conform to the ncon style.