### PR TITLE
Avoid using strings in `nconstyle` checks and errors

### DIFF
--- a/ext/TensorOperationsChainRulesCoreExt.jl
+++ b/ext/TensorOperationsChainRulesCoreExt.jl
@@ -340,7 +340,7 @@ end
 # NCON functions
 @non_differentiable TensorOperations.ncontree(args...)
 @non_differentiable TensorOperations.nconoutput(args...)
-@non_differentiable TensorOperations.isnconstyle(args...)
+@non_differentiable TensorOperations.check_nconstyle(args...)
 @non_differentiable TensorOperations.indexordertree(args...)
 
 end

--- a/src/implementation/ncon.jl
+++ b/src/implementation/ncon.jl
@@ -28,7 +28,7 @@ function ncon(
     )
     length(tensors) == length(network) == length(conjlist) ||
         throw(ArgumentError("number of tensors and of index lists should be the same"))
-    nconstylecheck(network) # asserts that the network is in ncon style
+    check_nconstyle(network)
     output′ = nconoutput(network, output)
 
     if length(tensors) == 1

--- a/src/indexnotation/contractiontrees.jl
+++ b/src/indexnotation/contractiontrees.jl
@@ -215,7 +215,7 @@ function defaulttreesorter(args, tree, depth)
 end
 
 function defaulttreebuilder(network)
-    if isnconstyle(network)
+    if check_nconstyle(Bool, network)
         tree = ncontree(network)
     else
         tree = Any[1, 2]

--- a/src/indexnotation/ncontree.jl
+++ b/src/indexnotation/ncontree.jl
@@ -1,10 +1,8 @@
 # Verify if a list of indices specifies a tensor contraction in ncon style.
-check_nconstyle(::Type{Bool}, network) = _check_nconstyle_error(network, Val(true))
-check_nconstyle(network) = (_check_nconstyle_error(network, Val(false)); nothing)
+check_nconstyle(::Type{Bool}, network) = _check_nconstyle(network, Val(true))
+check_nconstyle(network) = _check_nconstyle(network, Val(false))
 
-isnconstyle(network) = check_nconstyle(Bool, network)
-
-function _check_nconstyle_error(network, ::Val{check}) where {check}
+function _check_nconstyle(network, ::Val{check}) where {check}
     allindices = Vector{Int}()
     for ind in network
         all(i -> isa(i, Integer), ind) || return check ? false :
@@ -28,7 +26,7 @@ function _check_nconstyle_error(network, ::Val{check}) where {check}
             return check ? false : throw(IndexError("Index 0 is not allowed in the network"))
         end
     end
-    return true
+    return check ? true : nothing
 end
 
 function ncontree(network)

--- a/src/indexnotation/ncontree.jl
+++ b/src/indexnotation/ncontree.jl
@@ -12,7 +12,7 @@ isnconstyle(network) = check_nconstyle(Bool, network)
 function _check_nconstyle_error(network, ::Val{check}) where {check}
     allindices = Vector{Int}()
     for ind in network
-        all(i -> isa(i, Integer), ind) && return check ? false :
+        all(i -> isa(i, Integer), ind) || return check ? false :
             throw(IndexError("All indices must be integers"))
         append!(allindices, ind)
     end

--- a/src/indexnotation/ncontree.jl
+++ b/src/indexnotation/ncontree.jl
@@ -1,9 +1,4 @@
-"""
-    check_nconstyle(::Type{Bool}, network) -> Bool
-    check_nconstyle(network) -> Nothing
-    
-Verify if a list of indices specifies a tensor contraction in ncon style.
-"""
+# Verify if a list of indices specifies a tensor contraction in ncon style.
 check_nconstyle(::Type{Bool}, network) = _check_nconstyle_error(network, Val(true))
 check_nconstyle(network) = (_check_nconstyle_error(network, Val(false)); nothing)
 


### PR DESCRIPTION
This is a small follow up to #216 that avoids having to deal with strings in the `isnconstyle` function. In the end it probably doesn't matter all that much, but I slightly prefer this.

I also changed the function name to more closely reflect `Base.checkbounds` etc, to keep some consistency with the rest of the ecosystem. Again, just a minor change so if anyone disagrees I'm also happy to change it back.