### PR TITLE
Qualify constructor of `CUDAAllocator` in cuTENSOR extension

### DIFF
--- a/ext/TensorOperationscuTENSORExt.jl
+++ b/ext/TensorOperationscuTENSORExt.jl
@@ -147,7 +147,7 @@ end
 #-------------------------------------------------------------------------------------------
 # Allocator
 #-------------------------------------------------------------------------------------------
-function CUDAAllocator()
+function TO.CUDAAllocator()
     Mout = CUDA.UnifiedMemory
     Min = CUDA.default_memory
     Mtemp = CUDA.default_memory


### PR DESCRIPTION
This fixes the warning
```
┌ TensorOperations → TensorOperationscuTENSORExt
│  WARNING: Constructor for type "CUDAAllocator" was extended in `TensorOperationscuTENSORExt` without explicit qualification or import.
│    NOTE: Assumed "CUDAAllocator" refers to `TensorOperations.CUDAAllocator`. This behavior is deprecated and may differ in future versions.
│    NOTE: This behavior may have differed in Julia versions prior to 1.12.
│    Hint: If you intended to create a new generic function of the same name, use `function CUDAAllocator end`.
│    Hint: To silence the warning, qualify `CUDAAllocator` as `TensorOperations.CUDAAllocator` in the method signature or explicitly `import TensorOperations: CUDAAllocator`.
└  
```
when precompiling the extension.