### PR TITLE
add Reactant backend

### DIFF
--- a/src/backends.jl
+++ b/src/backends.jl
@@ -84,6 +84,6 @@ struct cuTENSORBackend <: AbstractBackend end
 """
     ReactantBackend
 
-Backend for tensor operations that works on top of Reactant.jl library.
+Backend for tensor operations that work on top of [Reactant.jl](https://github.com/EnzymeAD/Reactant.jl) library.
 """
 struct ReactantBackend <: AbstractBackend end

--- a/src/backends.jl
+++ b/src/backends.jl
@@ -78,3 +78,12 @@ const StridedBackend = Union{StridedNative, StridedBLAS}
 Backend for tensor operations that is based on the NVIDIA cuTENSOR library.
 """
 struct cuTENSORBackend <: AbstractBackend end
+
+# Reactant backend
+#-----------------
+"""
+    ReactantBackend
+
+Backend for tensor operations that works on top of Reactant.jl library.
+"""
+struct ReactantBackend <: AbstractBackend end

--- a/src/implementation/allocator.jl
+++ b/src/implementation/allocator.jl
@@ -70,6 +70,15 @@ mutable struct BufferAllocator{Storage}
     end
 end
 
+"""
+    ReactantAllocator{IsTraced}
+
+Allocator for Reactant-backed arrays. If `IsTraced=true`, it is supposed that Reactant is
+tracing the code and thus, it will return a `TracedRArray`.Otherwise, it will allocate a 
+`ConcreteRArray`.
+"""
+struct ReactantAllocator{IsTraced} end
+
 const DefaultStorageType = @static isdefined(Core, :Memory) ? Memory{UInt8} : Vector{UInt8}
 BufferAllocator(; kwargs...) = BufferAllocator{DefaultStorageType}(; kwargs...)
 

--- a/src/implementation/allocator.jl
+++ b/src/implementation/allocator.jl
@@ -73,8 +73,9 @@ end
 """
     ReactantAllocator{IsTraced}
 
-Allocator for Reactant-backed arrays. If `IsTraced=true`, it is supposed that Reactant is
-tracing the code and thus, it will return a `TracedRArray`.Otherwise, it will allocate a 
+Allocator for [Reactant](https://github.com/EnzymeAD/Reactant.jl)-backed arrays.
+If `IsTraced=true`, it is supposed that [Reactant](https://github.com/EnzymeAD/Reactant.jl)
+is tracing the code and thus, it will return a `TracedRArray`. Otherwise, it will allocate a 
 `ConcreteRArray`.
 """
 struct ReactantAllocator{IsTraced} end


### PR DESCRIPTION
I'm still deciding whether integration should live in the Reactant.jl repo or here. The main reason for the code to be in Reactant.jl is that we are prone to breaking things (we are not even fulfilling SemVer yet) so it may be a headache for you to maintain it.

Although this doesn't need any experimental/fancy part of Reactant and the part that it uses is quite stable, I fear that it might still silently break in the future.

In any case, this PR adds the `ReactantBackend` backend that's enough to start experimenting. If you want to have the full integration in this repo, I can push the rest of the changes to this PR.